### PR TITLE
feat: bootstrap gem skeleton and executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.bundle/
+.rspec_status
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
+AllCops:
+  NewCops: enable
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Style/Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gemspec
+
+group :mcp do
+  gem "fast-mcp", require: false
+end
+
+group :development, :test do
+  gem "rspec", "~> 3.13"
+  gem "rubocop-rails-omakase", require: false
+end

--- a/exe/gem-docs
+++ b/exe/gem-docs
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "gem_docs"
+
+exit GemDocs::CLI.start(ARGV)

--- a/exe/gem-docs-server
+++ b/exe/gem-docs-server
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "gem_docs/mcp/server"
+
+exit GemDocs::MCP::Server.start(ARGV)

--- a/gem-docs.gemspec
+++ b/gem-docs.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "lib/gem_docs/version"
+
 Gem::Specification.new do |spec|
   spec.name = "gem-docs"
-  spec.version = "0.1.0"
+  spec.version = GemDocs::VERSION
   spec.authors = [ "GitHub Copilot CLI" ]
   spec.email = [ "noreply@github.com" ]
 

--- a/gem-docs.gemspec
+++ b/gem-docs.gemspec
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "gem-docs"
+  spec.version = "0.1.0"
+  spec.authors = [ "GitHub Copilot CLI" ]
+  spec.email = [ "noreply@github.com" ]
+
+  spec.summary = "CLI-first gem documentation lookup for local Ruby projects"
+  spec.description = "Provides a CLI-first interface for local gem documentation with an optional MCP server wrapper."
+  spec.homepage = "https://github.com/alaexeyshustov/gem-docs-mcp-server"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.2"
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => spec.homepage,
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.files = Dir.chdir(__dir__) do
+    Dir["Gemfile", "README.md", "exe/*", "lib/**/*.rb", "spec/**/*.rb"]
+  end
+  spec.bindir = "exe"
+  spec.executables = [ "gem-docs", "gem-docs-server" ]
+  spec.require_paths = [ "lib" ]
+
+  spec.add_dependency "dry-cli", "~> 1.0"
+  spec.add_dependency "prism", "~> 1.4"
+  spec.add_dependency "yard", "~> 0.9"
+end

--- a/lib/gem_docs.rb
+++ b/lib/gem_docs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "gem_docs/version"
+require "gem_docs/cli"
+require "gem_docs/formatters"
+require "gem_docs/mcp"
+
+module GemDocs
+end

--- a/lib/gem_docs/cli.rb
+++ b/lib/gem_docs/cli.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "gem_docs/commands"
+
+module GemDocs
+  module CLI
+    HELP_FLAGS = [ "-h", "--help", "help" ].freeze
+    HELP_TEXT = <<~HELP.freeze
+      gem-docs — CLI-first local gem documentation
+
+      Usage:
+        gem-docs <command> [options]
+
+      Commands:
+        list
+        summary
+        classes
+        lookup
+        search
+        context
+        server
+    HELP
+
+    COMMANDS = {
+      "list" => GemDocs::Commands::List,
+      "summary" => GemDocs::Commands::Summary,
+      "classes" => GemDocs::Commands::Classes,
+      "lookup" => GemDocs::Commands::Lookup,
+      "search" => GemDocs::Commands::Search,
+      "context" => GemDocs::Commands::Context,
+      "server" => GemDocs::Commands::Server
+    }.freeze
+
+    module_function
+
+    def start(arguments, out: $stdout, err: $stderr)
+      return render_help(out) if arguments.empty? || HELP_FLAGS.include?(arguments.first)
+
+      command_class = COMMANDS[arguments.first]
+      return render_unknown_command(arguments.first, out: out, err: err) unless command_class
+
+      command_class.new(out: out, err: err).call(arguments.drop(1))
+    end
+
+    def render_help(out)
+      out.puts HELP_TEXT
+      0
+    end
+
+    def render_unknown_command(command_name, out:, err:)
+      err.puts "Unknown command: #{command_name}"
+      1
+    end
+  end
+end

--- a/lib/gem_docs/cli.rb
+++ b/lib/gem_docs/cli.rb
@@ -37,7 +37,7 @@ module GemDocs
       return render_help(out) if arguments.empty? || HELP_FLAGS.include?(arguments.first)
 
       command_class = COMMANDS[arguments.first]
-      return render_unknown_command(arguments.first, out: out, err: err) unless command_class
+      return render_unknown_command(arguments.first, err: err) unless command_class
 
       command_class.new(out: out, err: err).call(arguments.drop(1))
     end
@@ -47,7 +47,7 @@ module GemDocs
       0
     end
 
-    def render_unknown_command(command_name, out:, err:)
+    def render_unknown_command(command_name, err:)
       err.puts "Unknown command: #{command_name}"
       1
     end

--- a/lib/gem_docs/commands.rb
+++ b/lib/gem_docs/commands.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "gem_docs/commands/base"
+require "gem_docs/commands/classes"
+require "gem_docs/commands/context"
+require "gem_docs/commands/list"
+require "gem_docs/commands/lookup"
+require "gem_docs/commands/search"
+require "gem_docs/commands/server"
+require "gem_docs/commands/summary"
+
+module GemDocs
+  module Commands
+  end
+end

--- a/lib/gem_docs/commands/base.rb
+++ b/lib/gem_docs/commands/base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class Base
+      attr_reader :out, :err
+
+      def initialize(out:, err:)
+        @out = out
+        @err = err
+      end
+
+      def placeholder(command_name)
+        out.puts "#{command_name} is not implemented yet."
+        0
+      end
+    end
+  end
+end

--- a/lib/gem_docs/commands/classes.rb
+++ b/lib/gem_docs/commands/classes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class Classes < Base
+      def call(_arguments = [])
+        placeholder("classes")
+      end
+    end
+  end
+end

--- a/lib/gem_docs/commands/context.rb
+++ b/lib/gem_docs/commands/context.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class Context < Base
+      def call(_arguments = [])
+        placeholder("context")
+      end
+    end
+  end
+end

--- a/lib/gem_docs/commands/list.rb
+++ b/lib/gem_docs/commands/list.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class List < Base
+      def call(_arguments = [])
+        placeholder("list")
+      end
+    end
+  end
+end

--- a/lib/gem_docs/commands/lookup.rb
+++ b/lib/gem_docs/commands/lookup.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class Lookup < Base
+      def call(_arguments = [])
+        placeholder("lookup")
+      end
+    end
+  end
+end

--- a/lib/gem_docs/commands/search.rb
+++ b/lib/gem_docs/commands/search.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class Search < Base
+      def call(_arguments = [])
+        placeholder("search")
+      end
+    end
+  end
+end

--- a/lib/gem_docs/commands/server.rb
+++ b/lib/gem_docs/commands/server.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class Server < Base
+      def call(arguments = [])
+        GemDocs::MCP::Server.start(arguments, out: out, err: err)
+      end
+    end
+  end
+end

--- a/lib/gem_docs/commands/server.rb
+++ b/lib/gem_docs/commands/server.rb
@@ -4,6 +4,8 @@ module GemDocs
   module Commands
     class Server < Base
       def call(arguments = [])
+        require "gem_docs/mcp/server"
+
         GemDocs::MCP::Server.start(arguments, out: out, err: err)
       end
     end

--- a/lib/gem_docs/commands/summary.rb
+++ b/lib/gem_docs/commands/summary.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Commands
+    class Summary < Base
+      def call(_arguments = [])
+        placeholder("summary")
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters.rb
+++ b/lib/gem_docs/formatters.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "gem_docs/formatters/json"
+require "gem_docs/formatters/text"
+
+module GemDocs
+  module Formatters
+  end
+end

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "json"
+
+module GemDocs
+  module Formatters
+    class Json
+      def call(payload)
+        JSON.pretty_generate(payload)
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    class Text
+      def call(payload)
+        payload.to_s
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp.rb
+++ b/lib/gem_docs/mcp.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+  end
+end

--- a/lib/gem_docs/mcp.rb
+++ b/lib/gem_docs/mcp.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "gem_docs/mcp/server"
-
 module GemDocs
   module MCP
   end

--- a/lib/gem_docs/mcp.rb
+++ b/lib/gem_docs/mcp.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "gem_docs/mcp/server"
+
 module GemDocs
   module MCP
   end

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+    class Server
+      def self.start(_arguments = [], out: $stdout, err: $stderr)
+        require "fast_mcp"
+
+        out.puts "gem-docs-server placeholder loaded"
+        0
+      rescue LoadError
+        err.puts "gem-docs-server requires the optional fast-mcp gem."
+        1
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -4,14 +4,24 @@ module GemDocs
   module MCP
     class Server
       def self.start(_arguments = [], out: $stdout, err: $stderr)
-        require "fast_mcp"
+        return 1 unless load_fast_mcp(err)
 
         out.puts "gem-docs-server placeholder loaded"
         0
+      end
+
+      def self.load_fast_mcp(err)
+        require "fast_mcp"
+        true
       rescue LoadError
         err.puts "gem-docs-server requires the optional fast-mcp gem."
-        1
+        false
+      rescue StandardError => e
+        err.puts "gem-docs-server failed to load fast-mcp: #{e.class}: #{e.message}"
+        false
       end
+
+      private_class_method :load_fast_mcp
     end
   end
 end

--- a/lib/gem_docs/version.rb
+++ b/lib/gem_docs/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module GemDocs
+  VERSION = "0.1.0"
+end

--- a/spec/bootstrap_structure_spec.rb
+++ b/spec/bootstrap_structure_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe "bootstrap structure" do
+  let(:repo_root) { Pathname(__dir__).join("..").expand_path }
+
+  it "creates the expected CLI-first filesystem layout" do
+    expected_paths = %w[
+      exe/gem-docs
+      exe/gem-docs-server
+      lib/gem_docs.rb
+      lib/gem_docs/cli.rb
+      lib/gem_docs/version.rb
+      lib/gem_docs/commands.rb
+      lib/gem_docs/commands/list.rb
+      lib/gem_docs/commands/summary.rb
+      lib/gem_docs/commands/classes.rb
+      lib/gem_docs/commands/lookup.rb
+      lib/gem_docs/commands/search.rb
+      lib/gem_docs/commands/context.rb
+      lib/gem_docs/commands/server.rb
+      lib/gem_docs/formatters.rb
+      lib/gem_docs/formatters/text.rb
+      lib/gem_docs/formatters/json.rb
+      lib/gem_docs/mcp.rb
+      lib/gem_docs/mcp/server.rb
+    ]
+
+    expected_paths.each do |relative_path|
+      expect(repo_root.join(relative_path)).to exist
+    end
+  end
+
+  it "marks both executables as runnable" do
+    expect(repo_root.join("exe/gem-docs")).to be_executable
+    expect(repo_root.join("exe/gem-docs-server")).to be_executable
+  end
+
+  it "declares the runtime, development, and optional dependencies from the PRD" do
+    spec = Gem::Specification.load(repo_root.join("gem-docs.gemspec").to_s)
+    gemfile = repo_root.join("Gemfile").read
+
+    expect(spec.required_ruby_version).to eq(Gem::Requirement.new(">= 3.2"))
+    expect(spec.executables).to contain_exactly("gem-docs", "gem-docs-server")
+    expect(spec.version.to_s).to eq(GemDocs::VERSION)
+    expect(spec.runtime_dependencies.map(&:name)).to contain_exactly("dry-cli", "prism", "yard")
+
+    expect(gemfile).to include('group :mcp do')
+    expect(gemfile).to include('gem "fast-mcp", require: false')
+    expect(gemfile).to include('gem "rspec", "~> 3.13"')
+    expect(gemfile).to include('gem "rubocop-rails-omakase", require: false')
+  end
+end

--- a/spec/executables_load_spec.rb
+++ b/spec/executables_load_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe "executables" do
     expect("#{stdout}\n#{stderr}").to include("gem-docs-server")
   end
 
+  it "routes the CLI server command through the MCP server loader" do
+    stdout, stderr, status = run_command("ruby", "-Ilib", "exe/gem-docs", "server")
+
+    expect(status).to be_success
+    expect(stderr).to eq("")
+    expect(stdout).to include("gem-docs-server placeholder loaded")
+  end
+
   it "keeps fast-mcp isolated from the default CLI load path" do
     stdout, stderr, status = run_command("ruby", "-Ilib", "-e", "require 'gem_docs'; puts $LOADED_FEATURES.grep(/fast_mcp/).empty?")
 

--- a/spec/executables_load_spec.rb
+++ b/spec/executables_load_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
 
 RSpec.describe "executables" do
   let(:repo_root) { Pathname(__dir__).join("..").expand_path }
@@ -31,11 +32,28 @@ RSpec.describe "executables" do
     expect(stdout).to include("gem-docs-server placeholder loaded")
   end
 
+  it "reports fast-mcp load failures from the CLI server command without a stack trace" do
+    Dir.mktmpdir do |tmpdir|
+      File.write(File.join(tmpdir, "fast_mcp.rb"), "raise RuntimeError, 'simulated fast_mcp load failure'\n")
+
+      stdout, stderr, status = run_command("ruby", "-I#{tmpdir}", "-Ilib", "exe/gem-docs", "server")
+
+      expect(status.exitstatus).to eq(1)
+      expect(stdout).to eq("")
+      expect(stderr).to eq("gem-docs-server failed to load fast-mcp: RuntimeError: simulated fast_mcp load failure\n")
+    end
+  end
+
   it "keeps fast-mcp isolated from the default CLI load path" do
-    stdout, stderr, status = run_command("ruby", "-Ilib", "-e", "require 'gem_docs'; puts $LOADED_FEATURES.grep(/fast_mcp/).empty?")
+    stdout, stderr, status = run_command(
+      "ruby",
+      "-Ilib",
+      "-e",
+      "require 'gem_docs'; puts [$LOADED_FEATURES.grep(/fast_mcp/).empty?, $LOADED_FEATURES.grep(/gem_docs\\/mcp\\/server/).empty?].join(':')"
+    )
 
     expect(status).to be_success
     expect(stderr).to eq("")
-    expect(stdout).to eq("true\n")
+    expect(stdout).to eq("true:true\n")
   end
 end

--- a/spec/executables_load_spec.rb
+++ b/spec/executables_load_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "executables" do
+  let(:repo_root) { Pathname(__dir__).join("..").expand_path }
+
+  def run_command(*command)
+    Open3.capture3(*command, chdir: repo_root.to_s)
+  end
+
+  it "loads the CLI executable without missing file errors" do
+    stdout, stderr, status = run_command("ruby", "-Ilib", "exe/gem-docs")
+
+    expect(status).to be_success
+    expect("#{stdout}\n#{stderr}").to include("gem-docs")
+  end
+
+  it "loads the server executable and reports the optional fast-mcp dependency cleanly" do
+    stdout, stderr, status = run_command("ruby", "-Ilib", "exe/gem-docs-server")
+
+    expect(status).to be_success
+    expect("#{stdout}\n#{stderr}").to include("gem-docs-server")
+  end
+
+  it "keeps fast-mcp isolated from the default CLI load path" do
+    stdout, stderr, status = run_command("ruby", "-Ilib", "-e", "require 'gem_docs'; puts $LOADED_FEATURES.grep(/fast_mcp/).empty?")
+
+    expect(status).to be_success
+    expect(stderr).to eq("")
+    expect(stdout).to eq("true\n")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "open3"
+require "pathname"
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.example_status_persistence_file_path = ".rspec_status"
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+end


### PR DESCRIPTION
## Summary
- bootstrap the initial gem skeleton, executables, and dependency wiring
- isolate MCP-specific loading so CLI usage does not require fast-mcp
- add coverage for executable loading, dependency wiring, and filesystem layout

Closes #2

## Test plan
- [x] bundle exec rspec
- [x] bundle exec rubocop

🤖 Generated with GitHub Copilot CLI