### PR TITLE
refactor: switch gem loading to zeitwerk

### DIFF
--- a/exe/gem-docs-server
+++ b/exe/gem-docs-server
@@ -3,6 +3,6 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
-require "gem_docs/mcp/server"
+require "gem_docs"
 
 exit GemDocs::MCP::Server.start(ARGV)

--- a/gem-docs.gemspec
+++ b/gem-docs.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-cli", "~> 1.0"
   spec.add_dependency "prism", "~> 1.4"
   spec.add_dependency "yard", "~> 0.9"
+  spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/lib/gem_docs.rb
+++ b/lib/gem_docs.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-require "gem_docs/version"
-require "gem_docs/cli"
-require "gem_docs/formatters"
-require "gem_docs/mcp"
+require "zeitwerk"
+
+loader = Zeitwerk::Loader.for_gem
+loader.inflector.inflect(
+  "cli" => "CLI",
+  "mcp" => "MCP"
+)
+loader.setup
 
 module GemDocs
 end

--- a/lib/gem_docs/cli.rb
+++ b/lib/gem_docs/cli.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "gem_docs/commands"
-
 module GemDocs
   module CLI
     HELP_FLAGS = [ "-h", "--help", "help" ].freeze
@@ -22,13 +20,13 @@ module GemDocs
     HELP
 
     COMMANDS = {
-      "list" => GemDocs::Commands::List,
-      "summary" => GemDocs::Commands::Summary,
-      "classes" => GemDocs::Commands::Classes,
-      "lookup" => GemDocs::Commands::Lookup,
-      "search" => GemDocs::Commands::Search,
-      "context" => GemDocs::Commands::Context,
-      "server" => GemDocs::Commands::Server
+      "list" => "List",
+      "summary" => "Summary",
+      "classes" => "Classes",
+      "lookup" => "Lookup",
+      "search" => "Search",
+      "context" => "Context",
+      "server" => "Server"
     }.freeze
 
     module_function
@@ -36,9 +34,10 @@ module GemDocs
     def start(arguments, out: $stdout, err: $stderr)
       return render_help(out) if arguments.empty? || HELP_FLAGS.include?(arguments.first)
 
-      command_class = COMMANDS[arguments.first]
-      return render_unknown_command(arguments.first, err: err) unless command_class
+      command_name = COMMANDS[arguments.first]
+      return render_unknown_command(arguments.first, err: err) unless command_name
 
+      command_class = GemDocs::Commands.const_get(command_name, false)
       command_class.new(out: out, err: err).call(arguments.drop(1))
     end
 

--- a/lib/gem_docs/commands.rb
+++ b/lib/gem_docs/commands.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-require "gem_docs/commands/base"
-require "gem_docs/commands/classes"
-require "gem_docs/commands/context"
-require "gem_docs/commands/list"
-require "gem_docs/commands/lookup"
-require "gem_docs/commands/search"
-require "gem_docs/commands/server"
-require "gem_docs/commands/summary"
-
 module GemDocs
   module Commands
   end

--- a/lib/gem_docs/formatters.rb
+++ b/lib/gem_docs/formatters.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "gem_docs/formatters/json"
-require "gem_docs/formatters/text"
-
 module GemDocs
   module Formatters
   end

--- a/spec/bootstrap_structure_spec.rb
+++ b/spec/bootstrap_structure_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "bootstrap structure" do
     expect(spec.required_ruby_version).to eq(Gem::Requirement.new(">= 3.2"))
     expect(spec.executables).to contain_exactly("gem-docs", "gem-docs-server")
     expect(spec.version.to_s).to eq(GemDocs::VERSION)
-    expect(spec.runtime_dependencies.map(&:name)).to contain_exactly("dry-cli", "prism", "yard")
+    expect(spec.runtime_dependencies.map(&:name)).to contain_exactly("dry-cli", "prism", "yard", "zeitwerk")
 
     expect(gemfile).to include('group :mcp do')
     expect(gemfile).to include('gem "fast-mcp", require: false')

--- a/spec/zeitwerk_loading_spec.rb
+++ b/spec/zeitwerk_loading_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Zeitwerk loading" do
+  let(:repo_root) { Pathname(__dir__).join("..").expand_path }
+
+  def run_ruby(code)
+    Open3.capture3("ruby", "-Ilib", "-e", code, chdir: repo_root.to_s)
+  end
+
+  it "does not eagerly load command implementations when requiring gem_docs" do
+    stdout, stderr, status = run_ruby(<<~RUBY)
+      require "gem_docs"
+
+      puts $LOADED_FEATURES.grep(/gem_docs\\/commands\\/list\\.rb$/).empty?
+    RUBY
+
+    expect(status).to be_success
+    expect(stderr).to eq("")
+    expect(stdout).to eq("true\n")
+  end
+
+  it "does not eagerly load command implementations when resolving the CLI constant" do
+    stdout, stderr, status = run_ruby(<<~RUBY)
+      require "gem_docs"
+      GemDocs::CLI
+
+      puts $LOADED_FEATURES.grep(/gem_docs\\/commands\\/list\\.rb$/).empty?
+    RUBY
+
+    expect(status).to be_success
+    expect(stderr).to eq("")
+    expect(stdout).to eq("true\n")
+  end
+
+  it "autoloads command, formatter, and MCP constants on demand" do
+    stdout, stderr, status = run_ruby(<<~RUBY)
+      require "gem_docs"
+
+      puts [
+        GemDocs::Commands::List.name,
+        GemDocs::Formatters::Text.name,
+        GemDocs::MCP::Server.name
+      ].join(",")
+    RUBY
+
+    expect(status).to be_success
+    expect(stderr).to eq("")
+    expect(stdout).to eq("GemDocs::Commands::List,GemDocs::Formatters::Text,GemDocs::MCP::Server\n")
+  end
+end


### PR DESCRIPTION
## Summary
- configure the gem entrypoint with a Zeitwerk loader and custom inflections for CLI/MCP
- remove redundant manual requires and make CLI command resolution lazy
- add loading specs and declare Zeitwerk as a runtime dependency

Closes #15

## Test plan
- bundle exec rubocop
- bundle exec rspec