### PR TITLE
refactor: use dry-cli for CLI surface

### DIFF
--- a/lib/gem_docs/cli.rb
+++ b/lib/gem_docs/cli.rb
@@ -4,6 +4,7 @@ require "dry/cli"
 
 module GemDocs
   module CLI
+    COMMAND_STATUS_TAG = :gem_docs_command_status
     HELP_FLAGS = [ "-h", "--help", "help" ].freeze
     COMMAND_REGISTRATIONS = {
       "classes" => "Classes",
@@ -21,7 +22,12 @@ module GemDocs
     def start(arguments, out: $stdout, err: $stderr)
       return render_help(out) if arguments.empty? || HELP_FLAGS.include?(arguments.first)
 
-      Dry::CLI.new(build_registry).call(arguments: arguments, out: out, err: err) || 0
+      status = catch(COMMAND_STATUS_TAG) do
+        Dry::CLI.new(build_registry).call(arguments: arguments, out: out, err: err)
+        0
+      end
+
+      status || 0
     rescue SystemExit => e
       e.status
     end
@@ -36,10 +42,23 @@ module GemDocs
         extend Dry::CLI::Registry
       end.tap do |registry|
         COMMAND_REGISTRATIONS.each do |command_name, constant_name|
-          registry.register(command_name, GemDocs::Commands.const_get(constant_name, false))
+          command_class = GemDocs::Commands.const_get(constant_name, false)
+          registry.register(command_name, build_command_adapter(command_class))
         end
       end
     end
     private_class_method :build_registry
+
+    def build_command_adapter(command_class)
+      Class.new(command_class) do
+        desc command_class.description if command_class.description
+        example command_class.examples if command_class.examples.any?
+
+        define_method(:call) do |**kwargs|
+          throw(COMMAND_STATUS_TAG, super(**kwargs))
+        end
+      end
+    end
+    private_class_method :build_command_adapter
   end
 end

--- a/lib/gem_docs/cli.rb
+++ b/lib/gem_docs/cli.rb
@@ -1,54 +1,45 @@
 # frozen_string_literal: true
 
+require "dry/cli"
+
 module GemDocs
   module CLI
     HELP_FLAGS = [ "-h", "--help", "help" ].freeze
-    HELP_TEXT = <<~HELP.freeze
-      gem-docs — CLI-first local gem documentation
-
-      Usage:
-        gem-docs <command> [options]
-
-      Commands:
-        list
-        summary
-        classes
-        lookup
-        search
-        context
-        server
-    HELP
-
-    COMMANDS = {
-      "list" => "List",
-      "summary" => "Summary",
+    COMMAND_REGISTRATIONS = {
       "classes" => "Classes",
+      "context" => "Context",
+      "list" => "List",
       "lookup" => "Lookup",
       "search" => "Search",
-      "context" => "Context",
-      "server" => "Server"
+      "server" => "Server",
+      "summary" => "Summary"
     }.freeze
+    private_constant :COMMAND_REGISTRATIONS
 
     module_function
 
     def start(arguments, out: $stdout, err: $stderr)
       return render_help(out) if arguments.empty? || HELP_FLAGS.include?(arguments.first)
 
-      command_name = COMMANDS[arguments.first]
-      return render_unknown_command(arguments.first, err: err) unless command_name
-
-      command_class = GemDocs::Commands.const_get(command_name, false)
-      command_class.new(out: out, err: err).call(arguments.drop(1))
+      Dry::CLI.new(build_registry).call(arguments: arguments, out: out, err: err) || 0
+    rescue SystemExit => e
+      e.status
     end
 
     def render_help(out)
-      out.puts HELP_TEXT
+      out.puts Dry::CLI::Usage.call(build_registry.get([]))
       0
     end
 
-    def render_unknown_command(command_name, err:)
-      err.puts "Unknown command: #{command_name}"
-      1
+    def build_registry
+      Module.new do
+        extend Dry::CLI::Registry
+      end.tap do |registry|
+        COMMAND_REGISTRATIONS.each do |command_name, constant_name|
+          registry.register(command_name, GemDocs::Commands.const_get(constant_name, false))
+        end
+      end
     end
+    private_class_method :build_registry
   end
 end

--- a/lib/gem_docs/commands/base.rb
+++ b/lib/gem_docs/commands/base.rb
@@ -7,7 +7,7 @@ module GemDocs
     class Base < Dry::CLI::Command
       def placeholder(command_name)
         out.puts "#{command_name} is not implemented yet."
-        exit(0)
+        0
       end
     end
   end

--- a/lib/gem_docs/commands/base.rb
+++ b/lib/gem_docs/commands/base.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
+require "dry/cli"
+
 module GemDocs
   module Commands
-    class Base
-      attr_reader :out, :err
-
-      def initialize(out:, err:)
-        @out = out
-        @err = err
-      end
-
+    class Base < Dry::CLI::Command
       def placeholder(command_name)
         out.puts "#{command_name} is not implemented yet."
-        0
+        exit(0)
       end
     end
   end

--- a/lib/gem_docs/commands/classes.rb
+++ b/lib/gem_docs/commands/classes.rb
@@ -3,7 +3,9 @@
 module GemDocs
   module Commands
     class Classes < Base
-      def call(_arguments = [])
+      desc "List documented classes"
+
+      def call(**)
         placeholder("classes")
       end
     end

--- a/lib/gem_docs/commands/context.rb
+++ b/lib/gem_docs/commands/context.rb
@@ -3,7 +3,9 @@
 module GemDocs
   module Commands
     class Context < Base
-      def call(_arguments = [])
+      desc "Show project gem context"
+
+      def call(**)
         placeholder("context")
       end
     end

--- a/lib/gem_docs/commands/list.rb
+++ b/lib/gem_docs/commands/list.rb
@@ -3,7 +3,9 @@
 module GemDocs
   module Commands
     class List < Base
-      def call(_arguments = [])
+      desc "Show installed gems"
+
+      def call(**)
         placeholder("list")
       end
     end

--- a/lib/gem_docs/commands/lookup.rb
+++ b/lib/gem_docs/commands/lookup.rb
@@ -3,7 +3,9 @@
 module GemDocs
   module Commands
     class Lookup < Base
-      def call(_arguments = [])
+      desc "Look up a constant or method"
+
+      def call(**)
         placeholder("lookup")
       end
     end

--- a/lib/gem_docs/commands/search.rb
+++ b/lib/gem_docs/commands/search.rb
@@ -3,7 +3,9 @@
 module GemDocs
   module Commands
     class Search < Base
-      def call(_arguments = [])
+      desc "Search gem documentation"
+
+      def call(**)
         placeholder("search")
       end
     end

--- a/lib/gem_docs/commands/server.rb
+++ b/lib/gem_docs/commands/server.rb
@@ -3,10 +3,13 @@
 module GemDocs
   module Commands
     class Server < Base
-      def call(arguments = [])
+      desc "Start the MCP server"
+      argument :args, type: :array
+
+      def call(args: [], **)
         require "gem_docs/mcp/server"
 
-        GemDocs::MCP::Server.start(arguments, out: out, err: err)
+        exit GemDocs::MCP::Server.start(args, out: out, err: err)
       end
     end
   end

--- a/lib/gem_docs/commands/server.rb
+++ b/lib/gem_docs/commands/server.rb
@@ -9,7 +9,7 @@ module GemDocs
       def call(args: [], **)
         require "gem_docs/mcp/server"
 
-        exit GemDocs::MCP::Server.start(args, out: out, err: err)
+        GemDocs::MCP::Server.start(args, out: out, err: err)
       end
     end
   end

--- a/lib/gem_docs/commands/summary.rb
+++ b/lib/gem_docs/commands/summary.rb
@@ -3,7 +3,9 @@
 module GemDocs
   module Commands
     class Summary < Base
-      def call(_arguments = [])
+      desc "Summarize a gem"
+
+      def call(**)
         placeholder("summary")
       end
     end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::CLI do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  it "renders dry-cli help for the top-level help flag" do
+    status = described_class.start([ "--help" ], out: stdout, err: stderr)
+
+    expect(status).to eq(0)
+    expect(stderr.string).to eq("")
+    expect(stdout.string).to include("Commands:")
+    expect(stdout.string).to include("list")
+    expect(stdout.string).to include("Show installed gems")
+  end
+
+  it "renders dry-cli command help for subcommands" do
+    status = described_class.start([ "list", "--help" ], out: stdout, err: stderr)
+
+    expect(status).to eq(0)
+    expect(stderr.string).to eq("")
+    expect(stdout.string).to include("Command:")
+    expect(stdout.string).to include("Description:")
+    expect(stdout.string).to include("Show installed gems")
+  end
+
+  it "returns dry-cli usage for unknown commands" do
+    status = described_class.start([ "unknown" ], out: stdout, err: stderr)
+
+    expect(status).to eq(1)
+    expect(stdout.string).to eq("")
+    expect(stderr.string).to include("Commands:")
+    expect(stderr.string).to include("list")
+  end
+
+  it "dispatches registered commands through dry-cli" do
+    status = described_class.start([ "search" ], out: stdout, err: stderr)
+
+    expect(status).to eq(0)
+    expect(stderr.string).to eq("")
+    expect(stdout.string).to eq("search is not implemented yet.\n")
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "stringio"
 require "spec_helper"
 require "gem_docs"
 


### PR DESCRIPTION
## Summary
- replace the manual CLI dispatcher with a dry-cli registry built from command classes
- update command classes to inherit from Dry::CLI::Command and describe each command
- add CLI specs for top-level help, subcommand help, unknown commands, and dispatch

Closes #16

## Test plan
- bundle exec rspec
- bundle exec rubocop