### PR TITLE
feat: add shared config and error handling

### DIFF
--- a/lib/gem_docs.rb
+++ b/lib/gem_docs.rb
@@ -10,4 +10,15 @@ loader.inflector.inflect(
 loader.setup
 
 module GemDocs
+  module_function
+
+  def config(root: Dir.pwd)
+    @config_cache ||= {}
+    expanded_root = File.exist?(root) ? File.realpath(root) : File.expand_path(root)
+    @config_cache[expanded_root] ||= Config.load(root: expanded_root)
+  end
+
+  def reset_config_cache!
+    @config_cache = {}
+  end
 end

--- a/lib/gem_docs.rb
+++ b/lib/gem_docs.rb
@@ -10,15 +10,23 @@ loader.inflector.inflect(
 loader.setup
 
 module GemDocs
+  CONFIG_CACHE_MUTEX = Mutex.new
+  private_constant :CONFIG_CACHE_MUTEX
+
   module_function
 
   def config(root: Dir.pwd)
-    @config_cache ||= {}
     expanded_root = File.exist?(root) ? File.realpath(root) : File.expand_path(root)
-    @config_cache[expanded_root] ||= Config.load(root: expanded_root)
+
+    CONFIG_CACHE_MUTEX.synchronize do
+      @config_cache ||= {}
+      @config_cache[expanded_root] ||= Config.load(root: expanded_root)
+    end
   end
 
   def reset_config_cache!
-    @config_cache = {}
+    CONFIG_CACHE_MUTEX.synchronize do
+      @config_cache = {}
+    end
   end
 end

--- a/lib/gem_docs.rb
+++ b/lib/gem_docs.rb
@@ -16,7 +16,11 @@ module GemDocs
   module_function
 
   def config(root: Dir.pwd)
-    expanded_root = File.exist?(root) ? File.realpath(root) : File.expand_path(root)
+    expanded_root = begin
+      File.realpath(root)
+    rescue Errno::ENOENT, Errno::ELOOP, Errno::ENAMETOOLONG
+      File.expand_path(root)
+    end
 
     CONFIG_CACHE_MUTEX.synchronize do
       @config_cache ||= {}

--- a/lib/gem_docs/cli.rb
+++ b/lib/gem_docs/cli.rb
@@ -55,7 +55,13 @@ module GemDocs
         example command_class.examples if command_class.examples.any?
 
         define_method(:call) do |**kwargs|
-          throw(COMMAND_STATUS_TAG, super(**kwargs))
+          status = begin
+            super(**kwargs)
+          rescue GemDocs::Error => e
+            render_command_error(e, format: kwargs.fetch(:format, "text"))
+          end
+
+          throw(COMMAND_STATUS_TAG, status)
         end
       end
     end

--- a/lib/gem_docs/commands/base.rb
+++ b/lib/gem_docs/commands/base.rb
@@ -5,9 +5,31 @@ require "dry/cli"
 module GemDocs
   module Commands
     class Base < Dry::CLI::Command
+      option :format,
+             values: %w[text json],
+             default: "text",
+             desc: "Output format"
+
       def placeholder(command_name)
         out.puts "#{command_name} is not implemented yet."
         0
+      end
+
+      def render_command_error(error, format: "text")
+        err.puts(formatted_error(error, format: format))
+        1
+      end
+
+      private
+
+      def config
+        GemDocs.config(root: Dir.pwd)
+      end
+
+      def formatted_error(error, format:)
+        return error.message unless format == "json"
+
+        GemDocs::Formatters::Json.new.call(error.to_h)
       end
     end
   end

--- a/lib/gem_docs/config.rb
+++ b/lib/gem_docs/config.rb
@@ -5,6 +5,7 @@ require "yaml"
 module GemDocs
   class Config
     FILE_NAME = ".gem-docs.yml"
+    VALID_COLORS = %w[auto always never].freeze
     DEFAULTS = {
       gems: {
         exclude: []
@@ -66,7 +67,16 @@ module GemDocs
         path = File.join(root, FILE_NAME)
         return {} unless File.exist?(path)
 
-        normalize_hash(YAML.safe_load(File.read(path), aliases: false) || {})
+        raw_config = YAML.safe_load(File.read(path), aliases: false) || {}
+        unless raw_config.is_a?(Hash)
+          raise GemDocs::ConfigurationError.new("#{path} must contain a YAML mapping")
+        end
+
+        normalized_config = normalize_hash(raw_config)
+        validate_overrides!(normalized_config, path)
+        normalized_config
+      rescue Psych::SyntaxError => e
+        raise GemDocs::ConfigurationError.new("Invalid configuration in #{path}: #{e.message}")
       end
 
       def normalize_hash(value)
@@ -84,12 +94,53 @@ module GemDocs
 
       def deep_merge(base, overrides)
         base.merge(overrides) do |_key, base_value, override_value|
-          if base_value.is_a?(Hash) && override_value.is_a?(Hash)
+          if override_value.nil?
+            base_value
+          elsif base_value.is_a?(Hash) && override_value.is_a?(Hash)
             deep_merge(base_value, override_value)
           else
             override_value
           end
         end
+      end
+
+      def validate_overrides!(overrides, path)
+        validate_section_hash!(overrides, :gems, path)
+        validate_section_hash!(overrides, :doc_fallback, path)
+        validate_section_hash!(overrides, :output, path)
+
+        validate_array!(overrides.dig(:gems, :exclude), "#{path} gems.exclude") if overrides.dig(:gems, :exclude)
+        validate_boolean!(overrides.dig(:doc_fallback, :use_rdoc), "#{path} doc_fallback.use_rdoc") if overrides.dig(:doc_fallback, :use_rdoc) != nil
+        validate_boolean!(overrides.dig(:doc_fallback, :use_source_prism), "#{path} doc_fallback.use_source_prism") if overrides.dig(:doc_fallback, :use_source_prism) != nil
+
+        return unless overrides.dig(:output, :color)
+
+        validate_color!(overrides.dig(:output, :color), "#{path} output.color")
+      end
+
+      def validate_section_hash!(overrides, section, path)
+        value = overrides[section]
+        return if value.nil? || value.is_a?(Hash)
+
+        raise GemDocs::ConfigurationError.new("#{path} #{section} must be a mapping")
+      end
+
+      def validate_array!(value, location)
+        return if value.is_a?(Array)
+
+        raise GemDocs::ConfigurationError.new("#{location} must be an array")
+      end
+
+      def validate_boolean!(value, location)
+        return if value == true || value == false
+
+        raise GemDocs::ConfigurationError.new("#{location} must be true or false")
+      end
+
+      def validate_color!(value, location)
+        return if VALID_COLORS.include?(value)
+
+        raise GemDocs::ConfigurationError.new("#{location} must be one of: #{VALID_COLORS.join(', ')}")
       end
 
       def deep_freeze(value)

--- a/lib/gem_docs/config.rb
+++ b/lib/gem_docs/config.rb
@@ -65,8 +65,6 @@ module GemDocs
 
       def load_overrides(root)
         path = File.join(root, FILE_NAME)
-        return {} unless File.exist?(path)
-
         raw_config = YAML.safe_load(File.read(path), aliases: false) || {}
         unless raw_config.is_a?(Hash)
           raise GemDocs::ConfigurationError.new("#{path} must contain a YAML mapping")
@@ -75,6 +73,8 @@ module GemDocs
         normalized_config = normalize_hash(raw_config)
         validate_overrides!(normalized_config, path)
         normalized_config
+      rescue Errno::ENOENT
+        {}
       rescue Psych::SyntaxError => e
         raise GemDocs::ConfigurationError.new("Invalid configuration in #{path}: #{e.message}")
       end

--- a/lib/gem_docs/config.rb
+++ b/lib/gem_docs/config.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module GemDocs
+  class Config
+    FILE_NAME = ".gem-docs.yml"
+    DEFAULTS = {
+      gems: {
+        exclude: []
+      },
+      doc_fallback: {
+        use_rdoc: true,
+        use_source_prism: true
+      },
+      output: {
+        color: "auto"
+      }
+    }.freeze
+
+    def self.load(root: Dir.pwd)
+      new(deep_merge(DEFAULTS, load_overrides(root)))
+    end
+
+    def initialize(values)
+      @values = deep_freeze(values)
+    end
+
+    def to_h
+      self.class.deep_dup(@values)
+    end
+
+    def exclude_gems
+      @values.dig(:gems, :exclude)
+    end
+
+    def use_rdoc?
+      @values.dig(:doc_fallback, :use_rdoc)
+    end
+
+    def use_source_prism?
+      @values.dig(:doc_fallback, :use_source_prism)
+    end
+
+    def output_color
+      @values.dig(:output, :color)
+    end
+
+    class << self
+      def deep_dup(value)
+        case value
+        when Hash
+          value.each_with_object({}) do |(key, nested_value), duplicate|
+            duplicate[key] = deep_dup(nested_value)
+          end
+        when Array
+          value.map { |item| deep_dup(item) }
+        else
+          value
+        end
+      end
+
+      private
+
+      def load_overrides(root)
+        path = File.join(root, FILE_NAME)
+        return {} unless File.exist?(path)
+
+        normalize_hash(YAML.safe_load(File.read(path), aliases: false) || {})
+      end
+
+      def normalize_hash(value)
+        case value
+        when Hash
+          value.each_with_object({}) do |(key, nested_value), normalized|
+            normalized[key.to_sym] = normalize_hash(nested_value)
+          end
+        when Array
+          value.map { |item| normalize_hash(item) }
+        else
+          value
+        end
+      end
+
+      def deep_merge(base, overrides)
+        base.merge(overrides) do |_key, base_value, override_value|
+          if base_value.is_a?(Hash) && override_value.is_a?(Hash)
+            deep_merge(base_value, override_value)
+          else
+            override_value
+          end
+        end
+      end
+
+      def deep_freeze(value)
+        case value
+        when Hash
+          value.each_value { |nested_value| deep_freeze(nested_value) }
+        when Array
+          value.each { |item| deep_freeze(item) }
+        end
+
+        value.freeze
+      end
+    end
+
+    private
+
+    def deep_freeze(value)
+      self.class.send(:deep_freeze, value)
+    end
+  end
+end

--- a/lib/gem_docs/configuration_error.rb
+++ b/lib/gem_docs/configuration_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class ConfigurationError < Error
+    def error_code
+      "configuration_error"
+    end
+  end
+end

--- a/lib/gem_docs/doc_unavailable.rb
+++ b/lib/gem_docs/doc_unavailable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class DocUnavailable < Error
+    def initialize(subject, message: nil, details: {})
+      super(message || "Documentation is unavailable for '#{subject}'", details: details)
+    end
+
+    def error_code
+      "unavailable"
+    end
+  end
+end

--- a/lib/gem_docs/error.rb
+++ b/lib/gem_docs/error.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class Error < StandardError
+    attr_reader :details
+
+    def initialize(message, details: {})
+      super(message)
+      @details = details
+    end
+
+    def error_code
+      raise NotImplementedError
+    end
+
+    def to_h
+      { error: error_code, message: message }.tap do |payload|
+        payload[:details] = details unless details.empty?
+      end
+    end
+  end
+end

--- a/lib/gem_docs/gem_not_found.rb
+++ b/lib/gem_docs/gem_not_found.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class GemNotFound < Error
+    def initialize(gem_name, message: nil, details: {})
+      super(message || "Gem '#{gem_name}' is not installed", details: details)
+    end
+
+    def error_code
+      "not_found"
+    end
+  end
+end

--- a/lib/gem_docs/registry_error.rb
+++ b/lib/gem_docs/registry_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class RegistryError < Error
+    def initialize(message = "The gem documentation registry is unavailable", details: {})
+      super(message, details: details)
+    end
+
+    def error_code
+      "registry_error"
+    end
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "stringio"
 require "spec_helper"
 require "gem_docs"
@@ -43,5 +44,43 @@ RSpec.describe GemDocs::CLI do
     expect(status).to eq(0)
     expect(stderr.string).to eq("")
     expect(stdout.string).to eq("search is not implemented yet.\n")
+  end
+
+  it "renders structured JSON for handled command errors" do
+    stub_const("GemDocs::Commands::List", Class.new(GemDocs::Commands::Base) do
+      desc "Show installed gems"
+
+      def call(**)
+        raise GemDocs::GemNotFound.new("missing-gem")
+      end
+    end)
+
+    status = described_class.start([ "list", "--format", "json" ], out: stdout, err: stderr)
+
+    expect(status).to eq(1)
+    expect(stdout.string).to eq("")
+    expect(JSON.parse(stderr.string)).to eq(
+      "error" => "not_found",
+      "message" => "Gem 'missing-gem' is not installed"
+    )
+  end
+
+  it "renders unavailable errors with the shared JSON envelope" do
+    stub_const("GemDocs::Commands::Lookup", Class.new(GemDocs::Commands::Base) do
+      desc "Look up a constant or method"
+
+      def call(**)
+        raise GemDocs::DocUnavailable.new("missing-gem")
+      end
+    end)
+
+    status = described_class.start([ "lookup", "--format", "json" ], out: stdout, err: stderr)
+
+    expect(status).to eq(1)
+    expect(stdout.string).to eq("")
+    expect(JSON.parse(stderr.string)).to eq(
+      "error" => "unavailable",
+      "message" => "Documentation is unavailable for 'missing-gem'"
+    )
   end
 end

--- a/spec/commands/base_spec.rb
+++ b/spec/commands/base_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "gem_docs"
+
+RSpec.describe GemDocs::Commands::Base do
+  around do |example|
+    GemDocs.reset_config_cache!
+    example.run
+    GemDocs.reset_config_cache!
+  end
+
+  it "exposes the shared project config helper to commands" do
+    Dir.mktmpdir do |tmpdir|
+      File.write(
+        File.join(tmpdir, ".gem-docs.yml"),
+        <<~YAML
+          doc_fallback:
+            use_rdoc: false
+            use_source_prism: false
+        YAML
+      )
+
+      command = described_class.new
+
+      Dir.chdir(tmpdir) do
+        expect(command.send(:config)).to equal(GemDocs.config(root: tmpdir))
+        expect(command.send(:config).use_rdoc?).to be(false)
+        expect(command.send(:config).use_source_prism?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -50,4 +50,45 @@ RSpec.describe GemDocs::Config do
       )
     end
   end
+
+  it "preserves defaults when optional sections are present but empty" do
+    Dir.mktmpdir do |tmpdir|
+      File.write(
+        File.join(tmpdir, ".gem-docs.yml"),
+        <<~YAML
+          gems:
+          doc_fallback:
+        YAML
+      )
+
+      config = GemDocs.config(root: tmpdir)
+
+      expect(config.exclude_gems).to eq([])
+      expect(config.use_rdoc?).to be(true)
+      expect(config.use_source_prism?).to be(true)
+    end
+  end
+
+  it "raises a shared configuration error for malformed YAML" do
+    Dir.mktmpdir do |tmpdir|
+      File.write(File.join(tmpdir, ".gem-docs.yml"), "gems: [broken\n")
+
+      expect { GemDocs.config(root: tmpdir) }
+        .to raise_error(GemDocs::ConfigurationError, /Invalid configuration/)
+    end
+  end
+
+  it "raises a shared configuration error for invalid section types" do
+    Dir.mktmpdir do |tmpdir|
+      File.write(
+        File.join(tmpdir, ".gem-docs.yml"),
+        <<~YAML
+          gems: unexpected
+        YAML
+      )
+
+      expect { GemDocs.config(root: tmpdir) }
+        .to raise_error(GemDocs::ConfigurationError, /gems must be a mapping/)
+    end
+  end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "gem_docs"
+
+RSpec.describe GemDocs::Config do
+  around do |example|
+    GemDocs.reset_config_cache!
+    example.run
+    GemDocs.reset_config_cache!
+  end
+
+  it "returns sensible defaults when the config file is missing" do
+    Dir.mktmpdir do |tmpdir|
+      config = GemDocs.config(root: tmpdir)
+
+      expect(config.to_h).to eq(
+        gems: { exclude: [] },
+        doc_fallback: { use_rdoc: true, use_source_prism: true },
+        output: { color: "auto" }
+      )
+      expect(config.exclude_gems).to eq([])
+      expect(config.use_rdoc?).to be(true)
+      expect(config.use_source_prism?).to be(true)
+      expect(config.output_color).to eq("auto")
+    end
+  end
+
+  it "deep merges supported settings from .gem-docs.yml" do
+    Dir.mktmpdir do |tmpdir|
+      File.write(
+        File.join(tmpdir, ".gem-docs.yml"),
+        <<~YAML
+          gems:
+            exclude:
+              - bundler
+              - rake
+          output:
+            color: never
+        YAML
+      )
+
+      config = GemDocs.config(root: tmpdir)
+
+      expect(config.to_h).to eq(
+        gems: { exclude: [ "bundler", "rake" ] },
+        doc_fallback: { use_rdoc: true, use_source_prism: true },
+        output: { color: "never" }
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared project config loader with sensible defaults and cached accessors
- introduce shared GemDocs domain errors plus JSON error rendering for CLI commands
- cover config loading, command config access, and structured error handling with specs

Closes #3

## Test Plan
- bundle exec rspec
- bundle exec rubocop