### PR TITLE
feat: add doc registry fallback chain

### DIFF
--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -26,27 +26,67 @@ module GemDocs
     end
 
     class LoadedGem
+      MISSING = Object.new
+      private_constant :MISSING
+
       attr_reader :name, :version, :summary, :path, :doc_source, :objects
 
-      def initialize(name:, version:, summary:, path:, doc_source:, objects:, dynamic_lookup: nil)
+      def initialize(name:, version:, summary:, path:, doc_source:, objects:, dynamic_lookup: nil, lazy_paths: [])
         @name = name
         @version = version
         @summary = summary
         @path = path
         @doc_source = doc_source
-        @objects = objects.freeze
+        @objects = objects.dup
         @dynamic_lookup = dynamic_lookup
+        @lazy_paths = lazy_paths.each_with_object({}) do |lazy_path, pending|
+          pending[lazy_path] = true
+        end
         @object_map = objects.each_with_object({}) do |object, map|
           map[object.path] = object
         end
       end
 
       def find(path)
-        @object_map[path] ||= @dynamic_lookup&.call(path)
+        cached = @object_map[path]
+        return nil if cached.equal?(MISSING)
+
+        if @lazy_paths.delete(path)
+          return cache_lookup(path, @dynamic_lookup&.call(path), fallback: cached)
+        end
+
+        return cached if cached
+
+        cache_lookup(path, @dynamic_lookup&.call(path))
       end
 
       def classes
-        objects.select(&:class_or_module?)
+        @lazy_paths.keys.each { |path| find(path) }
+        @objects.select(&:class_or_module?)
+      end
+
+      private
+
+      def cache_lookup(path, result, fallback: nil)
+        cached = result || fallback || MISSING
+        @object_map[path] = cached
+
+        if cached.equal?(MISSING)
+          nil
+        else
+          replace_object(path, cached)
+          cached
+        end
+      end
+
+      def replace_object(path, object)
+        index = @objects.index { |existing| existing.path == path }
+
+        if index
+          @objects[index] = object
+        else
+          @objects << object
+        end
       end
     end
 
@@ -102,7 +142,8 @@ module GemDocs
           path: spec.full_gem_path,
           doc_source: :rdoc,
           objects: rdoc_objects,
-          dynamic_lookup: ->(path) { load_rdoc_object(spec, path) }
+          dynamic_lookup: ->(path) { load_rdoc_object(spec, path) },
+          lazy_paths: rdoc_objects.map(&:path)
         )
       else
         objects = load_source_objects(spec)
@@ -156,35 +197,27 @@ module GemDocs
     def load_rdoc_objects(spec)
       return unless File.directory?(spec.doc_dir)
 
-      response = run_shell(*ri_command(spec, "-l"))
+      response = run_shell(*ri_list_command(spec))
+      return if command_execution_failed?(response)
+
       raise GemDocs::RegistryError.new("Failed to load ri registry: #{response[:stderr]}") unless response[:success]
 
       names = response[:stdout].lines.map(&:strip).reject(&:empty?)
       return if names.empty?
 
-      names.filter_map do |name|
-        load_rdoc_namespace(spec, name)
+      names.map do |name|
+        build_rdoc_index_entry(name)
       end
     end
 
-    def load_rdoc_namespace(spec, name)
-      response = run_shell(*ri_command(spec, name))
-      return unless response[:success]
-
-      signature, docstring = parse_rdoc_output(response[:stdout])
-      kind = if signature.start_with?("module ")
-        :module
-      else
-        :class
-      end
-
+    def build_rdoc_index_entry(name)
       Entry.new(
         path: name,
         name: name.split("::").last,
-        kind: kind,
+        kind: :class,
         visibility: :public,
-        docstring: docstring,
-        signature: signature.empty? ? name : signature,
+        docstring: "",
+        signature: name,
         source_location: nil,
         superclass: nil,
         doc_source: :rdoc
@@ -199,7 +232,7 @@ module GemDocs
       Entry.new(
         path: path,
         name: path.split(/[#.]/).last,
-        kind: rdoc_kind_for(path),
+        kind: rdoc_kind_for(path, signature),
         visibility: :public,
         docstring: docstring,
         signature: signature.empty? ? path : signature,
@@ -265,11 +298,11 @@ module GemDocs
 
     def parse_source_file(file)
       result = Prism.parse_file(file)
-      stack = [ [ result.value, nil ] ]
+      stack = [ [ result.value, nil, false ] ]
       objects = []
 
       until stack.empty?
-        node, namespace_path = stack.pop
+        node, namespace_path, class_method_context = stack.pop
 
         case node
         when Prism::ClassNode
@@ -291,10 +324,15 @@ module GemDocs
             line: node.location.start_line
           )
           push_children(stack, node, module_path)
+        when Prism::SingletonClassNode
+          next unless node.expression.is_a?(Prism::SelfNode)
+
+          push_children(stack, node, namespace_path, true)
         when Prism::DefNode
           next unless namespace_path
 
-          method_path = if node.receiver.is_a?(Prism::SelfNode)
+          class_method = class_method_context || node.receiver.is_a?(Prism::SelfNode)
+          method_path = if class_method
             "#{namespace_path}.#{node.name}"
           else
             "#{namespace_path}##{node.name}"
@@ -302,10 +340,10 @@ module GemDocs
           objects << Entry.new(
             path: method_path,
             name: node.name.to_s,
-            kind: node.receiver.is_a?(Prism::SelfNode) ? :class_method : :instance_method,
+            kind: class_method ? :class_method : :instance_method,
             visibility: :public,
             docstring: "",
-            signature: build_method_signature(namespace_path, node),
+            signature: build_method_signature(namespace_path, node, class_method: class_method),
             source_location: format_source_location(file, node.location.start_line),
             superclass: nil,
             doc_source: :source_only
@@ -324,7 +362,7 @@ module GemDocs
             doc_source: :source_only
           )
         else
-          push_children(stack, node, namespace_path)
+          push_children(stack, node, namespace_path, class_method_context)
         end
       end
 
@@ -345,8 +383,8 @@ module GemDocs
       )
     end
 
-    def build_method_signature(namespace_path, node)
-      receiver_separator = node.receiver.is_a?(Prism::SelfNode) ? "." : "#"
+    def build_method_signature(namespace_path, node, class_method:)
+      receiver_separator = class_method ? "." : "#"
       parameter_list = format_parameter_list(node.parameters&.signature || [])
       "#{namespace_path}#{receiver_separator}#{node.name}(#{parameter_list.join(', ')})"
     end
@@ -421,32 +459,45 @@ module GemDocs
       [ signature, Array(doc_lines).join("\n").strip ]
     end
 
-    def rdoc_kind_for(path)
+    def rdoc_kind_for(path, signature)
       return :instance_method if path.include?("#")
       return :class_method if path.match?(/\.[A-Za-z_]/)
       return :constant if path.split("::").last == path.split("::").last.upcase
+      return :module if signature.start_with?("module ")
 
       :class
     end
 
+    def ri_list_command(spec)
+      [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "-l" ]
+    end
+
     def ri_command(spec, *arguments)
-      [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, *arguments ]
+      [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "--", *arguments ]
     end
 
     def run_shell(*command)
       @shell_runner.call(command)
+    rescue SystemCallError => e
+      { stdout: "", stderr: e.message, success: false, error: e }
     end
 
     def run_command(command)
       stdout, stderr, status = Open3.capture3(*command)
       { stdout: stdout, stderr: stderr, success: status.success? }
+    rescue SystemCallError => e
+      { stdout: "", stderr: e.message, success: false, error: e }
     end
 
-    def push_children(stack, node, namespace_path)
+    def command_execution_failed?(response)
+      response[:error].is_a?(SystemCallError)
+    end
+
+    def push_children(stack, node, namespace_path, class_method_context = false)
       return unless node.respond_to?(:compact_child_nodes)
 
       node.compact_child_nodes.reverse_each do |child|
-        stack << [ child, namespace_path ]
+        stack << [ child, namespace_path, class_method_context ]
       end
     end
 

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -1,0 +1,472 @@
+# frozen_string_literal: true
+
+require "open3"
+require "prism"
+require "yard"
+
+module GemDocs
+  class DocRegistry
+    YARD_MUTEX = Mutex.new
+    private_constant :YARD_MUTEX
+
+    class Entry < Data.define(
+      :path,
+      :name,
+      :kind,
+      :visibility,
+      :docstring,
+      :signature,
+      :source_location,
+      :superclass,
+      :doc_source
+    )
+      def class_or_module?
+        kind == :class || kind == :module
+      end
+    end
+
+    class LoadedGem
+      attr_reader :name, :version, :summary, :path, :doc_source, :objects
+
+      def initialize(name:, version:, summary:, path:, doc_source:, objects:, dynamic_lookup: nil)
+        @name = name
+        @version = version
+        @summary = summary
+        @path = path
+        @doc_source = doc_source
+        @objects = objects.freeze
+        @dynamic_lookup = dynamic_lookup
+        @object_map = objects.each_with_object({}) do |object, map|
+          map[object.path] = object
+        end
+      end
+
+      def find(path)
+        @object_map[path] ||= @dynamic_lookup&.call(path)
+      end
+
+      def classes
+        objects.select(&:class_or_module?)
+      end
+    end
+
+    class << self
+      def gem_spec_for(name)
+        Gem::Specification.find_by_name(name)
+      rescue Gem::LoadError
+        nil
+      end
+    end
+
+    def initialize(shell_runner: nil)
+      @loaded_gems = {}
+      @shell_runner = shell_runner || method(:run_command)
+    end
+
+    def load_gem(name)
+      @loaded_gems.fetch(name) do
+        spec = self.class.gem_spec_for(name)
+        raise GemDocs::GemNotFound.new(name) unless spec
+
+        @loaded_gems[name] = build_loaded_gem(spec)
+      end
+    end
+
+    def find_object(path, gem_name:)
+      loaded_gem = load_gem(gem_name)
+      loaded_gem.find(path) || find_in_ancestor_chain(loaded_gem, path)
+    end
+
+    def classes_for(gem_name)
+      load_gem(gem_name).classes.sort_by(&:path)
+    end
+
+    private
+
+    def build_loaded_gem(spec)
+      loaded_gem = if File.exist?(File.join(spec.full_gem_path, ".yardoc"))
+        objects = load_yard_objects(File.join(spec.full_gem_path, ".yardoc"))
+        LoadedGem.new(
+          name: spec.name,
+          version: spec.version.to_s,
+          summary: spec.summary,
+          path: spec.full_gem_path,
+          doc_source: :yard,
+          objects: objects
+        )
+      elsif (rdoc_objects = load_rdoc_objects(spec))
+        LoadedGem.new(
+          name: spec.name,
+          version: spec.version.to_s,
+          summary: spec.summary,
+          path: spec.full_gem_path,
+          doc_source: :rdoc,
+          objects: rdoc_objects,
+          dynamic_lookup: ->(path) { load_rdoc_object(spec, path) }
+        )
+      else
+        objects = load_source_objects(spec)
+        LoadedGem.new(
+          name: spec.name,
+          version: spec.version.to_s,
+          summary: spec.summary,
+          path: spec.full_gem_path,
+          doc_source: objects.empty? ? :none : :source_only,
+          objects: objects
+        )
+      end
+
+      loaded_gem
+    end
+
+    def load_yard_objects(yardoc)
+      YARD_MUTEX.synchronize do
+        previous_yardoc = YARD::Registry.yardoc_file
+        YARD::Registry.clear
+        YARD::Registry.load!(yardoc)
+
+        objects = []
+        queue = YARD::Registry.root.children.reverse
+
+        until queue.empty?
+          object = queue.pop
+
+          case object
+          when YARD::CodeObjects::ClassObject, YARD::CodeObjects::ModuleObject
+            objects << build_yard_namespace_entry(object)
+            queue.concat(object.constants(inherited: false).reverse)
+            queue.concat(object.meths(inherited: false).reverse)
+            queue.concat(object.children.grep(YARD::CodeObjects::NamespaceObject).reverse)
+          when YARD::CodeObjects::MethodObject
+            objects << build_yard_method_entry(object)
+          when YARD::CodeObjects::ConstantObject
+            objects << build_yard_constant_entry(object)
+          end
+        end
+
+        objects
+      ensure
+        YARD::Registry.clear
+        YARD::Registry.yardoc_file = previous_yardoc
+      end
+    rescue StandardError => e
+      raise GemDocs::RegistryError.new("Failed to load YARD registry: #{e.message}")
+    end
+
+    def load_rdoc_objects(spec)
+      return unless File.directory?(spec.doc_dir)
+
+      response = run_shell(*ri_command(spec, "-l"))
+      raise GemDocs::RegistryError.new("Failed to load ri registry: #{response[:stderr]}") unless response[:success]
+
+      names = response[:stdout].lines.map(&:strip).reject(&:empty?)
+      return if names.empty?
+
+      names.filter_map do |name|
+        load_rdoc_namespace(spec, name)
+      end
+    end
+
+    def load_rdoc_namespace(spec, name)
+      response = run_shell(*ri_command(spec, name))
+      return unless response[:success]
+
+      signature, docstring = parse_rdoc_output(response[:stdout])
+      kind = if signature.start_with?("module ")
+        :module
+      else
+        :class
+      end
+
+      Entry.new(
+        path: name,
+        name: name.split("::").last,
+        kind: kind,
+        visibility: :public,
+        docstring: docstring,
+        signature: signature.empty? ? name : signature,
+        source_location: nil,
+        superclass: nil,
+        doc_source: :rdoc
+      )
+    end
+
+    def load_rdoc_object(spec, path)
+      response = run_shell(*ri_command(spec, path))
+      return unless response[:success]
+
+      signature, docstring = parse_rdoc_output(response[:stdout])
+      Entry.new(
+        path: path,
+        name: path.split(/[#.]/).last,
+        kind: rdoc_kind_for(path),
+        visibility: :public,
+        docstring: docstring,
+        signature: signature.empty? ? path : signature,
+        source_location: nil,
+        superclass: nil,
+        doc_source: :rdoc
+      )
+    end
+
+    def build_yard_namespace_entry(object)
+      Entry.new(
+        path: object.path,
+        name: object.name.to_s,
+        kind: object.is_a?(YARD::CodeObjects::ClassObject) ? :class : :module,
+        visibility: object.visibility || :public,
+        docstring: object.docstring.to_s,
+        signature: object.path,
+        source_location: yard_source_location(object),
+        superclass: yard_superclass(object),
+        doc_source: :yard
+      )
+    end
+
+    def build_yard_method_entry(object)
+      Entry.new(
+        path: object.path,
+        name: object.name.to_s,
+        kind: object.scope == :class ? :class_method : :instance_method,
+        visibility: object.visibility || :public,
+        docstring: object.docstring.to_s,
+        signature: object.signature || object.path,
+        source_location: yard_source_location(object),
+        superclass: nil,
+        doc_source: :yard
+      )
+    end
+
+    def build_yard_constant_entry(object)
+      Entry.new(
+        path: object.path,
+        name: object.name.to_s,
+        kind: :constant,
+        visibility: object.visibility || :public,
+        docstring: object.docstring.to_s,
+        signature: object.path,
+        source_location: yard_source_location(object),
+        superclass: nil,
+        doc_source: :yard
+      )
+    end
+
+    def load_source_objects(spec)
+      ruby_files_for(spec).flat_map do |file|
+        parse_source_file(file)
+      end
+    end
+
+    def ruby_files_for(spec)
+      Array(spec.require_paths).flat_map do |require_path|
+        Dir.glob(File.join(spec.full_gem_path, require_path, "**", "*.rb"))
+      end.sort
+    end
+
+    def parse_source_file(file)
+      result = Prism.parse_file(file)
+      stack = [ [ result.value, nil ] ]
+      objects = []
+
+      until stack.empty?
+        node, namespace_path = stack.pop
+
+        case node
+        when Prism::ClassNode
+          class_path = join_constant_path(namespace_path, node.constant_path.slice)
+          objects << build_namespace_entry(
+            path: class_path,
+            kind: :class,
+            file: file,
+            line: node.location.start_line,
+            superclass: resolve_constant_reference(namespace_path, node.superclass&.slice)
+          )
+          push_children(stack, node, class_path)
+        when Prism::ModuleNode
+          module_path = join_constant_path(namespace_path, node.constant_path.slice)
+          objects << build_namespace_entry(
+            path: module_path,
+            kind: :module,
+            file: file,
+            line: node.location.start_line
+          )
+          push_children(stack, node, module_path)
+        when Prism::DefNode
+          next unless namespace_path
+
+          method_path = if node.receiver.is_a?(Prism::SelfNode)
+            "#{namespace_path}.#{node.name}"
+          else
+            "#{namespace_path}##{node.name}"
+          end
+          objects << Entry.new(
+            path: method_path,
+            name: node.name.to_s,
+            kind: node.receiver.is_a?(Prism::SelfNode) ? :class_method : :instance_method,
+            visibility: :public,
+            docstring: "",
+            signature: build_method_signature(namespace_path, node),
+            source_location: format_source_location(file, node.location.start_line),
+            superclass: nil,
+            doc_source: :source_only
+          )
+        when Prism::ConstantWriteNode
+          constant_path = join_constant_path(namespace_path, node.name.to_s)
+          objects << Entry.new(
+            path: constant_path,
+            name: node.name.to_s,
+            kind: :constant,
+            visibility: :public,
+            docstring: "",
+            signature: constant_path,
+            source_location: format_source_location(file, node.location.start_line),
+            superclass: nil,
+            doc_source: :source_only
+          )
+        else
+          push_children(stack, node, namespace_path)
+        end
+      end
+
+      objects
+    end
+
+    def build_namespace_entry(path:, kind:, file:, line:, superclass: nil)
+      Entry.new(
+        path: path,
+        name: path.split("::").last,
+        kind: kind,
+        visibility: :public,
+        docstring: "",
+        signature: path,
+        source_location: format_source_location(file, line),
+        superclass: superclass,
+        doc_source: :source_only
+      )
+    end
+
+    def build_method_signature(namespace_path, node)
+      receiver_separator = node.receiver.is_a?(Prism::SelfNode) ? "." : "#"
+      parameter_list = format_parameter_list(node.parameters&.signature || [])
+      "#{namespace_path}#{receiver_separator}#{node.name}(#{parameter_list.join(', ')})"
+    end
+
+    def format_parameter_list(parameters)
+      parameters.map do |type, name|
+        case type
+        when :req
+          name.to_s
+        when :opt
+          "#{name} = ?"
+        when :rest
+          "*#{name}"
+        when :post
+          name.to_s
+        when :keyreq
+          "#{name}:"
+        when :key
+          "#{name}: ?"
+        when :keyrest
+          "**#{name}"
+        when :block
+          "&#{name}"
+        else
+          name.to_s
+        end
+      end
+    end
+
+    def join_constant_path(namespace_path, constant_path)
+      return constant_path unless namespace_path
+
+      "#{namespace_path}::#{constant_path}"
+    end
+
+    def resolve_constant_reference(namespace_path, constant_path)
+      return if constant_path.nil?
+      return constant_path if constant_path.include?("::") || namespace_path.nil?
+
+      "#{namespace_path}::#{constant_path}"
+    end
+
+    def format_source_location(file, line)
+      "#{file}:#{line}"
+    end
+
+    def yard_source_location(object)
+      return unless object.file && object.line
+
+      format_source_location(object.file, object.line)
+    end
+
+    def yard_superclass(object)
+      return unless object.is_a?(YARD::CodeObjects::ClassObject)
+
+      superclass = object.superclass
+      return unless superclass
+
+      superclass.respond_to?(:path) ? superclass.path : superclass.to_s
+    end
+
+    def parse_rdoc_output(output)
+      lines = output.lines.map(&:rstrip)
+      signature = lines.first.to_s.strip
+      separator_index = lines.index("")
+      doc_lines = if separator_index
+        lines[(separator_index + 1)..]
+      else
+        lines[1..]
+      end
+
+      [ signature, Array(doc_lines).join("\n").strip ]
+    end
+
+    def rdoc_kind_for(path)
+      return :instance_method if path.include?("#")
+      return :class_method if path.match?(/\.[A-Za-z_]/)
+      return :constant if path.split("::").last == path.split("::").last.upcase
+
+      :class
+    end
+
+    def ri_command(spec, *arguments)
+      [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, *arguments ]
+    end
+
+    def run_shell(*command)
+      @shell_runner.call(command)
+    end
+
+    def run_command(command)
+      stdout, stderr, status = Open3.capture3(*command)
+      { stdout: stdout, stderr: stderr, success: status.success? }
+    end
+
+    def push_children(stack, node, namespace_path)
+      return unless node.respond_to?(:compact_child_nodes)
+
+      node.compact_child_nodes.reverse_each do |child|
+        stack << [ child, namespace_path ]
+      end
+    end
+
+    def find_in_ancestor_chain(loaded_gem, path)
+      namespace_path, separator, method_name = path.match(/\A(.+)([#.])([^#.]+)\z/)&.captures
+      return unless namespace_path
+
+      visited = {}
+      current_namespace = namespace_path
+
+      until current_namespace.nil? || visited[current_namespace]
+        visited[current_namespace] = true
+
+        namespace_object = loaded_gem.find(current_namespace)
+        current_namespace = namespace_object&.superclass
+        next unless current_namespace
+
+        match = loaded_gem.find("#{current_namespace}#{separator}#{method_name}")
+        return match if match
+      end
+    end
+  end
+end

--- a/spec/bootstrap_structure_spec.rb
+++ b/spec/bootstrap_structure_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "bootstrap structure" do
       lib/gem_docs.rb
       lib/gem_docs/cli.rb
       lib/gem_docs/version.rb
+      lib/gem_docs/doc_registry.rb
       lib/gem_docs/commands.rb
       lib/gem_docs/commands/list.rb
       lib/gem_docs/commands/summary.rb

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+require "yard"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::DocRegistry do
+  def build_fixture_spec(name, gem_root:, summary: "Fixture gem")
+    Gem::Specification.new do |spec|
+      spec.name = name
+      spec.version = "0.1.0"
+      spec.summary = summary
+      spec.files = Dir.chdir(gem_root) { Dir["lib/**/*.rb"] }
+      spec.require_paths = [ "lib" ]
+    end.tap do |spec|
+      spec.define_singleton_method(:full_gem_path) { gem_root }
+      spec.define_singleton_method(:doc_dir) { File.join(gem_root, "doc") }
+    end
+  end
+
+  def with_source_fixture_gem(name, source:)
+    Dir.mktmpdir do |tmpdir|
+      gem_root = File.join(tmpdir, name)
+      FileUtils.mkdir_p(File.join(gem_root, "lib"))
+      File.write(File.join(gem_root, "lib", "#{name}.rb"), source)
+      spec = build_fixture_spec(name, gem_root: gem_root)
+
+      allow(described_class).to receive(:gem_spec_for).with(name).and_return(spec)
+
+      yield spec
+    end
+  end
+
+  def with_empty_fixture_gem(name)
+    Dir.mktmpdir do |tmpdir|
+      gem_root = File.join(tmpdir, name)
+      FileUtils.mkdir_p(gem_root)
+      spec = build_fixture_spec(name, gem_root: gem_root)
+
+      allow(described_class).to receive(:gem_spec_for).with(name).and_return(spec)
+
+      yield spec
+    end
+  end
+
+  def with_yard_fixture_gem(name, source:)
+    Dir.mktmpdir do |tmpdir|
+      gem_root = File.join(tmpdir, name)
+      file = File.join(gem_root, "lib", "#{name}.rb")
+      yardoc = File.join(gem_root, ".yardoc")
+      FileUtils.mkdir_p(File.dirname(file))
+      File.write(file, source)
+
+      previous_yardoc = YARD::Registry.yardoc_file
+      YARD::Registry.clear
+      YARD.parse(file)
+      YARD::Registry.save(false, yardoc)
+      YARD::Registry.clear
+      YARD::Registry.yardoc_file = previous_yardoc
+
+      spec = build_fixture_spec(name, gem_root: gem_root)
+      allow(described_class).to receive(:gem_spec_for).with(name).and_return(spec)
+
+      yield spec
+    ensure
+      YARD::Registry.clear
+      YARD::Registry.yardoc_file = previous_yardoc
+    end
+  end
+
+  describe "#load_gem" do
+    it "falls back to Prism source parsing when structured docs are unavailable" do
+      with_source_fixture_gem("source_only", source: <<~RUBY) do
+        module SourceOnly
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        registry = described_class.new
+
+        loaded_gem = registry.load_gem("source_only")
+
+        expect(loaded_gem.doc_source).to eq(:source_only)
+        expect(registry.find_object("SourceOnly::Widget#call", gem_name: "source_only")&.signature)
+          .to eq("SourceOnly::Widget#call(input)")
+      end
+    end
+
+    it "loads a .yardoc registry and caches the normalized gem entry" do
+      with_yard_fixture_gem("well_documented", source: <<~RUBY) do
+        module WellDocumented
+          class Widget
+            # Performs work.
+            #
+            # @param input [String]
+            # @return [String]
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        registry = described_class.new
+
+        first_load = registry.load_gem("well_documented")
+        second_load = registry.load_gem("well_documented")
+
+        expect(first_load.doc_source).to eq(:yard)
+        expect(second_load).to equal(first_load)
+        expect(registry.find_object("WellDocumented::Widget#call", gem_name: "well_documented")&.docstring)
+          .to include("Performs work.")
+      end
+    end
+
+    it "falls back to ri data when a gem has no .yardoc cache" do
+      with_source_fixture_gem("rdoc_only", source: "# intentionally empty\n") do |spec|
+        FileUtils.mkdir_p(spec.doc_dir)
+
+        shell_runner = lambda do |command|
+          case command.last
+          when "-l"
+            { stdout: "RdocOnly::Widget\n", stderr: "", success: true }
+          when "RdocOnly::Widget"
+            { stdout: "class RdocOnly::Widget\n\nThe primary RDoc class.\n", stderr: "", success: true }
+          when "RdocOnly::Widget#call"
+            { stdout: "RdocOnly::Widget#call\n\nCalls through ri.\n", stderr: "", success: true }
+          else
+            { stdout: "", stderr: "Not found", success: false }
+          end
+        end
+
+        registry = described_class.new(shell_runner: shell_runner)
+
+        loaded_gem = registry.load_gem("rdoc_only")
+        object = registry.find_object("RdocOnly::Widget#call", gem_name: "rdoc_only")
+
+        expect(loaded_gem.doc_source).to eq(:rdoc)
+        expect(object&.doc_source).to eq(:rdoc)
+        expect(object&.docstring).to include("Calls through ri.")
+      end
+    end
+
+    it "returns :none when no documentation or Ruby source files are available" do
+      with_empty_fixture_gem("empty_fixture") do
+        registry = described_class.new
+
+        loaded_gem = registry.load_gem("empty_fixture")
+
+        expect(loaded_gem.doc_source).to eq(:none)
+        expect(loaded_gem.objects).to eq([])
+      end
+    end
+
+    it "raises GemDocs::GemNotFound for missing gems" do
+      allow(described_class).to receive(:gem_spec_for).with("missing-gem").and_return(nil)
+
+      registry = described_class.new
+
+      expect { registry.load_gem("missing-gem") }.to raise_error(GemDocs::GemNotFound)
+    end
+
+    it "wraps broken YARD registries in GemDocs::RegistryError" do
+      with_yard_fixture_gem("broken_yard", source: "module BrokenYard; end\n") do
+        allow(YARD::Registry).to receive(:load!).and_raise(StandardError, "boom")
+
+        registry = described_class.new
+
+        expect { registry.load_gem("broken_yard") }
+          .to raise_error(GemDocs::RegistryError, /Failed to load YARD registry: boom/)
+      end
+    end
+  end
+
+  describe "#find_object" do
+    it "walks inherited namespaces to resolve inherited instance methods" do
+      with_source_fixture_gem("inheritance_fixture", source: <<~RUBY) do
+        module InheritanceFixture
+          class Parent
+            def base_call(token)
+            end
+          end
+
+          class Child < Parent
+          end
+        end
+      RUBY
+        registry = described_class.new
+
+        object = registry.find_object("InheritanceFixture::Child#base_call", gem_name: "inheritance_fixture")
+
+        expect(object&.path).to eq("InheritanceFixture::Parent#base_call")
+        expect(object&.signature).to eq("InheritanceFixture::Parent#base_call(token)")
+      end
+    end
+
+    it "resolves class methods and constants from Prism source parsing" do
+      with_source_fixture_gem("lookup_fixture", source: <<~RUBY) do
+        module LookupFixture
+          class Widget
+            VERSION = "1.0.0"
+
+            def self.build(name:, **options)
+            end
+          end
+        end
+      RUBY
+        registry = described_class.new
+
+        method_object = registry.find_object("LookupFixture::Widget.build", gem_name: "lookup_fixture")
+        constant_object = registry.find_object("LookupFixture::Widget::VERSION", gem_name: "lookup_fixture")
+
+        expect(method_object&.signature).to eq("LookupFixture::Widget.build(name:, **options)")
+        expect(constant_object&.kind).to eq(:constant)
+      end
+    end
+  end
+
+  describe "#classes_for" do
+    it "returns class and module entries in alphabetical order" do
+      with_source_fixture_gem("class_listing", source: <<~RUBY) do
+        module ClassListing
+          module Utilities
+          end
+
+          class Widget
+            def call
+            end
+          end
+        end
+      RUBY
+        registry = described_class.new
+
+        classes = registry.classes_for("class_listing")
+
+        expect(classes.map(&:path)).to eq([
+          "ClassListing",
+          "ClassListing::Utilities",
+          "ClassListing::Widget"
+        ])
+        expect(classes.map(&:kind)).to eq([ :module, :module, :class ])
+      end
+    end
+  end
+end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -118,8 +118,11 @@ RSpec.describe GemDocs::DocRegistry do
     it "falls back to ri data when a gem has no .yardoc cache" do
       with_source_fixture_gem("rdoc_only", source: "# intentionally empty\n") do |spec|
         FileUtils.mkdir_p(spec.doc_dir)
+        commands = []
 
         shell_runner = lambda do |command|
+          commands << command
+
           case command.last
           when "-l"
             { stdout: "RdocOnly::Widget\n", stderr: "", success: true }
@@ -138,8 +141,61 @@ RSpec.describe GemDocs::DocRegistry do
         object = registry.find_object("RdocOnly::Widget#call", gem_name: "rdoc_only")
 
         expect(loaded_gem.doc_source).to eq(:rdoc)
+        expect(commands.count { |command| command.last == "RdocOnly::Widget" }).to eq(0)
         expect(object&.doc_source).to eq(:rdoc)
         expect(object&.docstring).to include("Calls through ri.")
+      end
+    end
+
+    it "caches missing ri lookups so they do not rerun external commands" do
+      with_source_fixture_gem("rdoc_cache", source: "# intentionally empty\n") do |spec|
+        FileUtils.mkdir_p(spec.doc_dir)
+        lookup_count = 0
+
+        shell_runner = lambda do |command|
+          case command.last
+          when "-l"
+            { stdout: "RdocCache::Widget\n", stderr: "", success: true }
+          when "RdocCache::Widget#missing"
+            lookup_count += 1
+            { stdout: "", stderr: "Not found", success: false }
+          else
+            { stdout: "class RdocCache::Widget\n", stderr: "", success: true }
+          end
+        end
+
+        registry = described_class.new(shell_runner: shell_runner)
+
+        2.times do
+          expect(registry.find_object("RdocCache::Widget#missing", gem_name: "rdoc_cache")).to be_nil
+        end
+
+        expect(lookup_count).to eq(1)
+      end
+    end
+
+    it "falls back to source parsing when ri cannot be executed" do
+      with_source_fixture_gem("ri_missing", source: <<~RUBY) do |spec|
+        module RiMissing
+          class Widget
+            def call
+            end
+          end
+        end
+      RUBY
+        FileUtils.mkdir_p(spec.doc_dir)
+
+        registry = described_class.new(
+          shell_runner: lambda do |_command|
+            raise Errno::ENOENT, "ri"
+          end
+        )
+
+        loaded_gem = registry.load_gem("ri_missing")
+
+        expect(loaded_gem.doc_source).to eq(:source_only)
+        expect(registry.find_object("RiMissing::Widget#call", gem_name: "ri_missing")&.signature)
+          .to eq("RiMissing::Widget#call()")
       end
     end
 
@@ -216,6 +272,54 @@ RSpec.describe GemDocs::DocRegistry do
         expect(constant_object&.kind).to eq(:constant)
       end
     end
+
+    it "treats methods inside class << self as class methods" do
+      with_source_fixture_gem("singleton_fixture", source: <<~RUBY) do
+        module SingletonFixture
+          class Widget
+            class << self
+              def build(name)
+              end
+            end
+          end
+        end
+      RUBY
+        registry = described_class.new
+
+        object = registry.find_object("SingletonFixture::Widget.build", gem_name: "singleton_fixture")
+
+        expect(object&.kind).to eq(:class_method)
+        expect(object&.signature).to eq("SingletonFixture::Widget.build(name)")
+      end
+    end
+
+    it "passes ri object lookups after an end-of-options marker" do
+      with_source_fixture_gem("rdoc_flags", source: "# intentionally empty\n") do |spec|
+        FileUtils.mkdir_p(spec.doc_dir)
+        commands = []
+
+        shell_runner = lambda do |command|
+          commands << command
+
+          case command.last
+          when "-l"
+            { stdout: "Flagged::Widget\n", stderr: "", success: true }
+          when "-Flagged"
+            { stdout: "class -Flagged\n", stderr: "", success: true }
+          else
+            { stdout: "", stderr: "Not found", success: false }
+          end
+        end
+
+        registry = described_class.new(shell_runner: shell_runner)
+
+        registry.find_object("-Flagged", gem_name: "rdoc_flags")
+
+        lookup_command = commands.find { |command| command.last == "-Flagged" }
+        expect(lookup_command).to include("--")
+        expect(lookup_command.index("--")).to be < lookup_command.index("-Flagged")
+      end
+    end
   end
 
   describe "#classes_for" do
@@ -242,6 +346,15 @@ RSpec.describe GemDocs::DocRegistry do
         ])
         expect(classes.map(&:kind)).to eq([ :module, :module, :class ])
       end
+    end
+  end
+
+  describe "private helpers" do
+    it "returns a failed response when a command is unavailable" do
+      response = described_class.new.send(:run_command, [ "missing-ri-command" ])
+
+      expect(response[:success]).to eq(false)
+      expect(response[:error]).to be_a(Errno::ENOENT)
     end
   end
 end


### PR DESCRIPTION
## Summary
- add GemDocs::DocRegistry with YARD -> ri -> Prism fallback loading
- normalize lookup/class enumeration APIs with cached per-gem entries and iterative inheritance lookup
- cover the new registry behavior with focused RSpec examples

Closes #4

## Test plan
- bundle exec rspec
- bundle exec rubocop

Generated with GitHub Copilot CLI