### PR TITLE
feat: add shared formatter layer

### DIFF
--- a/lib/gem_docs/commands/base.rb
+++ b/lib/gem_docs/commands/base.rb
@@ -27,9 +27,7 @@ module GemDocs
       end
 
       def formatted_error(error, format:)
-        return error.message unless format == "json"
-
-        GemDocs::Formatters::Json.new.call(error.to_h)
+        GemDocs::Formatters.for(format).error(error.to_h)
       end
     end
   end

--- a/lib/gem_docs/formatters.rb
+++ b/lib/gem_docs/formatters.rb
@@ -2,5 +2,17 @@
 
 module GemDocs
   module Formatters
+    module_function
+
+    def for(format)
+      case format.to_s
+      when "json"
+        Json.new
+      when "text"
+        Text.new
+      else
+        raise ArgumentError, "Unsupported formatter: #{format}"
+      end
+    end
   end
 end

--- a/lib/gem_docs/formatters/base.rb
+++ b/lib/gem_docs/formatters/base.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    class Base
+      private
+
+      def compact_value(value)
+        case value
+        when Hash
+          value.each_with_object({}) do |(key, nested_value), compacted|
+            normalized = compact_value(nested_value)
+            next if normalized.nil?
+            next if normalized.respond_to?(:empty?) && normalized.empty?
+
+            compacted[key] = normalized
+          end
+        when Array
+          value.filter_map do |nested_value|
+            normalized = compact_value(nested_value)
+            normalized unless normalized.respond_to?(:empty?) && normalized.empty?
+          end
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/base.rb
+++ b/lib/gem_docs/formatters/base.rb
@@ -5,6 +5,30 @@ module GemDocs
     class Base
       private
 
+      def normalize_gem(gem)
+        return compact_hash(gem) if gem.is_a?(Hash)
+
+        case gem
+        when GemDocs::DocRegistry::LoadedGem
+          compact_hash(
+            name: gem.name,
+            version: gem.version,
+            summary: gem.summary,
+            path: gem.path,
+            doc_source: gem.doc_source,
+            classes: gem.classes.map(&:path)
+          )
+        else
+          compact_hash(gem.to_h)
+        end
+      end
+
+      def normalize_entry(entry)
+        return compact_hash(entry) if entry.is_a?(Hash)
+
+        compact_hash(entry.to_h)
+      end
+
       def compact_value(value)
         case value
         when Hash
@@ -21,7 +45,13 @@ module GemDocs
             normalized unless normalized.respond_to?(:empty?) && normalized.empty?
           end
         else
-          value
+          value.is_a?(Symbol) ? value.to_s : value
+        end
+      end
+
+      def compact_hash(hash)
+        hash.each_with_object({}) do |(key, value), compacted|
+          compacted[key.to_sym] = value
         end
       end
     end

--- a/lib/gem_docs/formatters/context.rb
+++ b/lib/gem_docs/formatters/context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    module Context
+      FORMATTERS = {
+        "claude" => "Claude",
+        "cursor" => "Cursor",
+        "windsurf" => "Windsurf",
+        "copilot" => "Copilot",
+        "json" => "Json"
+      }.freeze
+
+      module_function
+
+      def for(format)
+        const_get(FORMATTERS.fetch(format.to_s), false).new
+      rescue KeyError
+        raise ArgumentError, "Unsupported context formatter: #{format}"
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/context/base.rb
+++ b/lib/gem_docs/formatters/context/base.rb
@@ -8,13 +8,14 @@ module GemDocs
 
         def documented_gems(gems)
           gems.filter_map do |gem|
+            normalized_gem = normalize_gem(gem)
             normalized = compact_value(
-              name: gem[:name],
-              version: gem[:version],
-              summary: gem[:summary],
-              doc_source: gem[:doc_source]&.to_s,
-              classes: gem[:classes],
-              entry_points: gem[:entry_points]
+              name: normalized_gem[:name],
+              version: normalized_gem[:version],
+              summary: normalized_gem[:summary],
+              doc_source: normalized_gem[:doc_source],
+              classes: normalized_gem[:classes],
+              entry_points: normalized_gem[:entry_points]
             )
 
             normalized unless normalized[:doc_source] == "none"

--- a/lib/gem_docs/formatters/context/base.rb
+++ b/lib/gem_docs/formatters/context/base.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    module Context
+      class Base < GemDocs::Formatters::Base
+        private
+
+        def documented_gems(gems)
+          gems.filter_map do |gem|
+            normalized = compact_value(
+              name: gem[:name],
+              version: gem[:version],
+              summary: gem[:summary],
+              doc_source: gem[:doc_source]&.to_s,
+              classes: gem[:classes],
+              entry_points: gem[:entry_points]
+            )
+
+            normalized unless normalized[:doc_source] == "none"
+          end
+        end
+
+        def gem_sections(gems)
+          documented_gems(gems).map do |gem|
+            lines = [ "## #{gem[:name]} (#{gem[:version]})" ]
+            lines << "- Summary: #{gem[:summary]}" if gem[:summary]
+            lines << "- Documentation: #{gem[:doc_source]}"
+            lines << "- Classes: #{gem[:classes].join(', ')}" if gem[:classes]
+            lines << "- Entry points: #{gem[:entry_points].join(', ')}" if gem[:entry_points]
+            lines.join("\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/context/claude.rb
+++ b/lib/gem_docs/formatters/context/claude.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    module Context
+      class Claude < Base
+        def call(gems:)
+          [ "# Gem documentation context", gem_sections(gems) ].flatten.join("\n\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/context/copilot.rb
+++ b/lib/gem_docs/formatters/context/copilot.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    module Context
+      class Copilot < Base
+        def call(gems:)
+          [ "# Copilot gem context", gem_sections(gems) ].flatten.join("\n\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/context/cursor.rb
+++ b/lib/gem_docs/formatters/context/cursor.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    module Context
+      class Cursor < Base
+        def call(gems:)
+          [ "# Cursor gem context", gem_sections(gems) ].flatten.join("\n\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/context/json.rb
+++ b/lib/gem_docs/formatters/context/json.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "json"
+
+module GemDocs
+  module Formatters
+    module Context
+      class Json < Base
+        def call(gems:)
+          JSON.pretty_generate({ gems: documented_gems(gems) })
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/context/json.rb
+++ b/lib/gem_docs/formatters/context/json.rb
@@ -7,7 +7,7 @@ module GemDocs
     module Context
       class Json < Base
         def call(gems:)
-          JSON.pretty_generate({ gems: documented_gems(gems) })
+          JSON.pretty_generate(compact_value(gems: documented_gems(gems)))
         end
       end
     end

--- a/lib/gem_docs/formatters/context/windsurf.rb
+++ b/lib/gem_docs/formatters/context/windsurf.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Formatters
+    module Context
+      class Windsurf < Base
+        def call(gems:)
+          [ "# Windsurf gem context", gem_sections(gems) ].flatten.join("\n\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -4,9 +4,44 @@ require "json"
 
 module GemDocs
   module Formatters
-    class Json
+    class Json < Base
       def call(payload)
         JSON.pretty_generate(payload)
+      end
+
+      def error(payload)
+        call(compact_value(payload))
+      end
+
+      def list(gems:)
+        call(gems.map { |gem| compact_entry(gem) })
+      end
+
+      def summary(gem:)
+        call(compact_entry(gem))
+      end
+
+      def classes(gem:, entries:)
+        call(
+          compact_value(
+            gem: gem,
+            classes: entries.map { |entry| compact_entry(entry) }
+          )
+        )
+      end
+
+      def lookup(result:)
+        call(compact_entry(result))
+      end
+
+      def search(results:)
+        call(results.map { |result| compact_entry(result) })
+      end
+
+      private
+
+      def compact_entry(payload)
+        compact_value(payload.transform_values { |value| value.is_a?(Symbol) ? value.to_s : value })
       end
     end
   end

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -14,34 +14,28 @@ module GemDocs
       end
 
       def list(gems:)
-        call(gems.map { |gem| compact_entry(gem) })
+        call(gems.map { |gem| compact_value(normalize_gem(gem)) })
       end
 
       def summary(gem:)
-        call(compact_entry(gem))
+        call(compact_value(normalize_gem(gem)))
       end
 
       def classes(gem:, entries:)
         call(
           compact_value(
             gem: gem,
-            classes: entries.map { |entry| compact_entry(entry) }
+            classes: entries.map { |entry| compact_value(normalize_entry(entry)) }
           )
         )
       end
 
       def lookup(result:)
-        call(compact_entry(result))
+        call(compact_value(normalize_entry(result)))
       end
 
       def search(results:)
-        call(results.map { |result| compact_entry(result) })
-      end
-
-      private
-
-      def compact_entry(payload)
-        compact_value(payload.transform_values { |value| value.is_a?(Symbol) ? value.to_s : value })
+        call(results.map { |result| compact_value(normalize_entry(result)) })
       end
     end
   end

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -2,9 +2,92 @@
 
 module GemDocs
   module Formatters
-    class Text
+    class Text < Base
       def call(payload)
         payload.to_s
+      end
+
+      def error(payload)
+        payload.fetch(:message)
+      end
+
+      def list(gems:)
+        rows = gems.map do |gem|
+          [
+            gem.fetch(:name),
+            gem.fetch(:version),
+            gem.fetch(:doc_source).to_s
+          ]
+        end
+        widths = column_widths([ %w[NAME VERSION DOC\ SOURCE], *rows ])
+
+        lines = [ format_row([ "NAME", "VERSION", "DOC SOURCE" ], widths) + "  SUMMARY" ]
+        gems.each do |gem|
+          summary = gem[:summary].to_s
+          line = format_row(
+            [
+              gem.fetch(:name),
+              gem.fetch(:version),
+              gem.fetch(:doc_source).to_s
+            ],
+            widths
+          )
+          lines << [ line, summary ].reject(&:empty?).join("  ")
+        end
+
+        lines.join("\n") + "\n"
+      end
+
+      def summary(gem:)
+        build_sections(
+          "#{gem.fetch(:name)} (#{gem.fetch(:version)})",
+          gem[:summary],
+          "Documentation: #{gem[:doc_source]}",
+          section("Classes", gem[:classes]),
+          section("Entry points", gem[:entry_points])
+        )
+      end
+
+      def classes(gem:, entries:)
+        build_sections(
+          "#{gem} classes",
+          *entries.map { |entry| "- #{entry.fetch(:path)}" }
+        )
+      end
+
+      def lookup(result:)
+        build_sections(
+          result.fetch(:path),
+          result[:signature],
+          result[:docstring],
+          "Source: #{result[:source_location]}"
+        )
+      end
+
+      def search(results:)
+        build_sections(*results.map { |result| "- #{result.fetch(:path)}" })
+      end
+
+      private
+
+      def build_sections(*lines)
+        lines.compact.reject(&:empty?).join("\n")
+      end
+
+      def column_widths(rows)
+        rows.transpose.map { |column| column.map(&:length).max }
+      end
+
+      def format_row(values, widths)
+        values.each_with_index.map do |value, index|
+          value.ljust(widths[index])
+        end.join("  ")
+      end
+
+      def section(title, values)
+        return if values.nil? || values.empty?
+
+        "#{title}: #{values.join(', ')}"
       end
     end
   end

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -39,33 +39,37 @@ module GemDocs
       end
 
       def summary(gem:)
+        normalized_gem = normalize_gem(gem)
+
         build_sections(
-          "#{gem.fetch(:name)} (#{gem.fetch(:version)})",
-          gem[:summary],
-          "Documentation: #{gem[:doc_source]}",
-          section("Classes", gem[:classes]),
-          section("Entry points", gem[:entry_points])
+          "#{normalized_gem.fetch(:name)} (#{normalized_gem.fetch(:version)})",
+          normalized_gem[:summary],
+          "Documentation: #{normalized_gem[:doc_source]}",
+          section("Classes", normalized_gem[:classes]),
+          section("Entry points", normalized_gem[:entry_points])
         )
       end
 
       def classes(gem:, entries:)
         build_sections(
           "#{gem} classes",
-          *entries.map { |entry| "- #{entry.fetch(:path)}" }
+          *entries.map { |entry| "- #{normalize_entry(entry).fetch(:path)}" }
         )
       end
 
       def lookup(result:)
+        normalized_result = normalize_entry(result)
+
         build_sections(
-          result.fetch(:path),
-          result[:signature],
-          result[:docstring],
-          "Source: #{result[:source_location]}"
+          normalized_result.fetch(:path),
+          normalized_result[:signature],
+          normalized_result[:docstring],
+          source_location_line(normalized_result[:source_location])
         )
       end
 
       def search(results:)
-        build_sections(*results.map { |result| "- #{result.fetch(:path)}" })
+        build_sections(*results.map { |result| "- #{normalize_entry(result).fetch(:path)}" })
       end
 
       private
@@ -88,6 +92,12 @@ module GemDocs
         return if values.nil? || values.empty?
 
         "#{title}: #{values.join(', ')}"
+      end
+
+      def source_location_line(source_location)
+        return if source_location.nil? || source_location.empty?
+
+        "Source: #{source_location}"
       end
     end
   end

--- a/spec/formatters/context_spec.rb
+++ b/spec/formatters/context_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "json"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Formatters::Context do
+  let(:gems) do
+    [
+      {
+        name: "rack",
+        version: "3.1.0",
+        summary: "HTTP toolkit",
+        doc_source: :yard,
+        classes: [ "Rack::Builder", "Rack::Request" ],
+        entry_points: [ "Rack::Builder.new" ]
+      },
+      {
+        name: "undocumented",
+        version: "0.1.0",
+        summary: "",
+        doc_source: :none,
+        classes: [],
+        entry_points: []
+      }
+    ]
+  end
+
+  describe ".for" do
+    it "returns the shared formatter implementation for each supported output" do
+      expect(described_class.for("claude")).to be_a(GemDocs::Formatters::Context::Claude)
+      expect(described_class.for("cursor")).to be_a(GemDocs::Formatters::Context::Cursor)
+      expect(described_class.for("windsurf")).to be_a(GemDocs::Formatters::Context::Windsurf)
+      expect(described_class.for("copilot")).to be_a(GemDocs::Formatters::Context::Copilot)
+      expect(described_class.for("json")).to be_a(GemDocs::Formatters::Context::Json)
+    end
+  end
+
+  it "renders compact Claude context for documented gems only" do
+    output = described_class.for("claude").call(gems: gems)
+
+    expect(output).to include("# Gem documentation context")
+    expect(output).to include("## rack (3.1.0)")
+    expect(output).to include("- Classes: Rack::Builder, Rack::Request")
+    expect(output).not_to include("undocumented")
+  end
+
+  it "renders compact JSON context for documented gems only" do
+    output = described_class.for("json").call(gems: gems)
+
+    expect(JSON.parse(output)).to eq(
+      "gems" => [
+        {
+          "name" => "rack",
+          "version" => "3.1.0",
+          "summary" => "HTTP toolkit",
+          "doc_source" => "yard",
+          "classes" => [ "Rack::Builder", "Rack::Request" ],
+          "entry_points" => [ "Rack::Builder.new" ]
+        }
+      ]
+    )
+  end
+end

--- a/spec/formatters/context_spec.rb
+++ b/spec/formatters/context_spec.rb
@@ -61,4 +61,21 @@ RSpec.describe GemDocs::Formatters::Context do
       ]
     )
   end
+
+  it "omits the gems key when every gem is undocumented" do
+    output = described_class.for("json").call(
+      gems: [
+        {
+          name: "undocumented",
+          version: "0.1.0",
+          summary: "",
+          doc_source: :none,
+          classes: [],
+          entry_points: []
+        }
+      ]
+    )
+
+    expect(JSON.parse(output)).to eq({})
+  end
 end

--- a/spec/formatters/json_spec.rb
+++ b/spec/formatters/json_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "json"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Formatters::Json do
+  describe ".for" do
+    it "resolves the shared formatter instance by format" do
+      expect(GemDocs::Formatters.for("json")).to be_a(described_class)
+      expect(GemDocs::Formatters.for("text")).to be_a(GemDocs::Formatters::Text)
+    end
+  end
+
+  describe "#error" do
+    it "renders compact structured errors without empty fields" do
+      formatter = described_class.new
+
+      output = formatter.error(
+        error: "not_found",
+        message: "Gem 'missing-gem' is not installed",
+        details: {}
+      )
+
+      expect(JSON.parse(output)).to eq(
+        "error" => "not_found",
+        "message" => "Gem 'missing-gem' is not installed"
+      )
+    end
+  end
+
+  describe "#list" do
+    it "omits empty values from gem payloads while preserving required fields" do
+      formatter = described_class.new
+
+      output = formatter.list(
+        gems: [
+          { name: "rack", version: "3.1.0", doc_source: :yard, summary: "HTTP toolkit" },
+          { name: "rbs", version: "3.4.0", doc_source: :source_only, summary: "" }
+        ]
+      )
+
+      expect(JSON.parse(output)).to eq(
+        [
+          {
+            "name" => "rack",
+            "version" => "3.1.0",
+            "doc_source" => "yard",
+            "summary" => "HTTP toolkit"
+          },
+          {
+            "name" => "rbs",
+            "version" => "3.4.0",
+            "doc_source" => "source_only"
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/formatters/json_spec.rb
+++ b/spec/formatters/json_spec.rb
@@ -5,6 +5,31 @@ require "spec_helper"
 require "gem_docs"
 
 RSpec.describe GemDocs::Formatters::Json do
+  def build_entry(path:, signature: path, docstring: "", source_location: nil, kind: :class)
+    GemDocs::DocRegistry::Entry.new(
+      path: path,
+      name: path.split(/[:#.]/).last,
+      kind: kind,
+      visibility: :public,
+      docstring: docstring,
+      signature: signature,
+      source_location: source_location,
+      superclass: nil,
+      doc_source: :yard
+    )
+  end
+
+  def build_loaded_gem(name:, version:, summary:, doc_source:, objects:)
+    GemDocs::DocRegistry::LoadedGem.new(
+      name: name,
+      version: version,
+      summary: summary,
+      path: "/tmp/#{name}",
+      doc_source: doc_source,
+      objects: objects
+    )
+  end
+
   describe ".for" do
     it "resolves the shared formatter instance by format" do
       expect(GemDocs::Formatters.for("json")).to be_a(described_class)
@@ -52,6 +77,128 @@ RSpec.describe GemDocs::Formatters::Json do
             "name" => "rbs",
             "version" => "3.4.0",
             "doc_source" => "source_only"
+          }
+        ]
+      )
+    end
+  end
+
+  describe "#summary" do
+    it "serializes LoadedGem objects returned by the registry" do
+      formatter = described_class.new
+      loaded_gem = build_loaded_gem(
+        name: "rack",
+        version: "3.1.0",
+        summary: "HTTP toolkit",
+        doc_source: :yard,
+        objects: [
+          build_entry(path: "Rack::Builder"),
+          build_entry(path: "Rack::Request")
+        ]
+      )
+
+      output = formatter.summary(gem: loaded_gem)
+
+      expect(JSON.parse(output)).to eq(
+        "name" => "rack",
+        "version" => "3.1.0",
+        "summary" => "HTTP toolkit",
+        "path" => "/tmp/rack",
+        "doc_source" => "yard",
+        "classes" => [ "Rack::Builder", "Rack::Request" ]
+      )
+    end
+  end
+
+  describe "#classes" do
+    it "serializes registry entries without requiring hash access" do
+      formatter = described_class.new
+
+      output = formatter.classes(
+        gem: "rack",
+        entries: [
+          build_entry(path: "Rack::Builder"),
+          build_entry(path: "Rack::Request", docstring: "Request wrapper")
+        ]
+      )
+
+      expect(JSON.parse(output)).to eq(
+        "gem" => "rack",
+        "classes" => [
+          {
+            "path" => "Rack::Builder",
+            "name" => "Builder",
+            "kind" => "class",
+            "visibility" => "public",
+            "signature" => "Rack::Builder",
+            "doc_source" => "yard"
+          },
+          {
+            "path" => "Rack::Request",
+            "name" => "Request",
+            "kind" => "class",
+            "visibility" => "public",
+            "docstring" => "Request wrapper",
+            "signature" => "Rack::Request",
+            "doc_source" => "yard"
+          }
+        ]
+      )
+    end
+  end
+
+  describe "#lookup" do
+    it "serializes registry entries without requiring hash access" do
+      formatter = described_class.new
+
+      output = formatter.lookup(
+        result: build_entry(
+          path: "Rack::Builder",
+          signature: "Rack::Builder",
+          docstring: "Builds Rack applications"
+        )
+      )
+
+      expect(JSON.parse(output)).to eq(
+        "path" => "Rack::Builder",
+        "name" => "Builder",
+        "kind" => "class",
+        "visibility" => "public",
+        "docstring" => "Builds Rack applications",
+        "signature" => "Rack::Builder",
+        "doc_source" => "yard"
+      )
+    end
+  end
+
+  describe "#search" do
+    it "serializes registry entries without requiring hash access" do
+      formatter = described_class.new
+
+      output = formatter.search(
+        results: [
+          build_entry(path: "Rack::Builder"),
+          build_entry(path: "Rack::Request")
+        ]
+      )
+
+      expect(JSON.parse(output)).to eq(
+        [
+          {
+            "path" => "Rack::Builder",
+            "name" => "Builder",
+            "kind" => "class",
+            "visibility" => "public",
+            "signature" => "Rack::Builder",
+            "doc_source" => "yard"
+          },
+          {
+            "path" => "Rack::Request",
+            "name" => "Request",
+            "kind" => "class",
+            "visibility" => "public",
+            "signature" => "Rack::Request",
+            "doc_source" => "yard"
           }
         ]
       )

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Formatters::Text do
+  describe "#list" do
+    it "renders aligned gem rows for CLI output" do
+      formatter = described_class.new
+
+      output = formatter.list(
+        gems: [
+          { name: "rack", version: "3.1.0", doc_source: :yard, summary: "HTTP toolkit" },
+          { name: "rbs", version: "3.4.0", doc_source: :source_only, summary: "" }
+        ]
+      )
+
+      expect(output.lines).to eq(
+        [
+          "NAME  VERSION  DOC SOURCE   SUMMARY\n",
+          "rack  3.1.0    yard         HTTP toolkit\n",
+          "rbs   3.4.0    source_only\n"
+        ]
+      )
+    end
+  end
+end

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -4,6 +4,31 @@ require "spec_helper"
 require "gem_docs"
 
 RSpec.describe GemDocs::Formatters::Text do
+  def build_entry(path:, signature: path, docstring: "", source_location: nil, kind: :class)
+    GemDocs::DocRegistry::Entry.new(
+      path: path,
+      name: path.split(/[:#.]/).last,
+      kind: kind,
+      visibility: :public,
+      docstring: docstring,
+      signature: signature,
+      source_location: source_location,
+      superclass: nil,
+      doc_source: :yard
+    )
+  end
+
+  def build_loaded_gem(name:, version:, summary:, doc_source:, objects:)
+    GemDocs::DocRegistry::LoadedGem.new(
+      name: name,
+      version: version,
+      summary: summary,
+      path: "/tmp/#{name}",
+      doc_source: doc_source,
+      objects: objects
+    )
+  end
+
   describe "#list" do
     it "renders aligned gem rows for CLI output" do
       formatter = described_class.new
@@ -22,6 +47,78 @@ RSpec.describe GemDocs::Formatters::Text do
           "rbs   3.4.0    source_only\n"
         ]
       )
+    end
+  end
+
+  describe "#summary" do
+    it "renders a LoadedGem returned by the registry" do
+      formatter = described_class.new
+      loaded_gem = build_loaded_gem(
+        name: "rack",
+        version: "3.1.0",
+        summary: "HTTP toolkit",
+        doc_source: :yard,
+        objects: [
+          build_entry(path: "Rack::Builder"),
+          build_entry(path: "Rack::Request")
+        ]
+      )
+
+      output = formatter.summary(gem: loaded_gem)
+
+      expect(output).to eq(
+        "rack (3.1.0)\n" \
+        "HTTP toolkit\n" \
+        "Documentation: yard\n" \
+        "Classes: Rack::Builder, Rack::Request"
+      )
+    end
+  end
+
+  describe "#classes" do
+    it "renders registry entries without requiring hash access" do
+      formatter = described_class.new
+
+      output = formatter.classes(
+        gem: "rack",
+        entries: [
+          build_entry(path: "Rack::Builder"),
+          build_entry(path: "Rack::Request")
+        ]
+      )
+
+      expect(output).to eq("rack classes\n- Rack::Builder\n- Rack::Request")
+    end
+  end
+
+  describe "#lookup" do
+    it "omits the source line when the entry has no source location" do
+      formatter = described_class.new
+
+      output = formatter.lookup(
+        result: build_entry(
+          path: "Rack::Builder",
+          signature: "Rack::Builder",
+          docstring: "Builds Rack applications"
+        )
+      )
+
+      expect(output).to eq("Rack::Builder\nRack::Builder\nBuilds Rack applications")
+    end
+  end
+
+  describe "#search" do
+    it "renders registry entries without requiring hash access" do
+      formatter = described_class.new
+
+      output = formatter.search(
+        results: [
+          build_entry(path: "Rack::Builder"),
+          build_entry(path: "Rack::Request")
+        ]
+      )
+
+      expect(output).to eq("- Rack::Builder\n- Rack::Request")
     end
   end
 end


### PR DESCRIPTION
## Summary
- add shared JSON and text formatter helpers for command output and structured errors
- scaffold context formatters for Claude, Cursor, Windsurf, Copilot, and JSON output
- cover the formatter layer with focused RSpec examples and wire command error rendering through the shared formatters

Closes #5

## Test plan
- bundle exec rspec
- bundle exec rubocop
- ruby -Ilib exe/gem-docs --help
- ruby -Ilib exe/gem-docs-server --help