### PR TITLE
feat: implement gem-docs list

### DIFF
--- a/lib/gem_docs/commands/list.rb
+++ b/lib/gem_docs/commands/list.rb
@@ -25,19 +25,17 @@ module GemDocs
         @doc_registry ||= GemDocs::DocRegistry.new
       end
 
-      def gem_payload(spec)
-        loaded_gem = doc_registry.load_gem(spec.name)
-
-        {
-          name: spec.name,
-          version: spec.version.to_s,
-          doc_source: loaded_gem.doc_source,
-          summary: spec.summary
-        }
-      rescue StandardError
-        {
-          name: spec.name,
-          version: spec.version.to_s,
+    def gem_payload(spec)
+      {
+        name: spec.name,
+        version: spec.version.to_s,
+        doc_source: doc_registry.doc_source_for(spec.name, spec: spec),
+        summary: spec.summary
+      }
+    rescue GemDocs::Error
+      {
+        name: spec.name,
+        version: spec.version.to_s,
           doc_source: :none,
           summary: spec.summary
         }

--- a/lib/gem_docs/commands/list.rb
+++ b/lib/gem_docs/commands/list.rb
@@ -5,8 +5,42 @@ module GemDocs
     class List < Base
       desc "Show installed gems"
 
-      def call(**_kwargs)
-        placeholder("list")
+      def call(format: "text", **_kwargs)
+        gems = installed_specs
+          .reject { |spec| config.exclude_gems.include?(spec.name) }
+          .sort_by(&:name)
+          .map { |spec| gem_payload(spec) }
+
+        out.puts GemDocs::Formatters.for(format).list(gems: gems)
+        0
+      end
+
+      private
+
+      def installed_specs
+        Gem::Specification.to_a
+      end
+
+      def doc_registry
+        @doc_registry ||= GemDocs::DocRegistry.new
+      end
+
+      def gem_payload(spec)
+        loaded_gem = doc_registry.load_gem(spec.name)
+
+        {
+          name: spec.name,
+          version: spec.version.to_s,
+          doc_source: loaded_gem.doc_source,
+          summary: spec.summary
+        }
+      rescue StandardError
+        {
+          name: spec.name,
+          version: spec.version.to_s,
+          doc_source: :none,
+          summary: spec.summary
+        }
       end
     end
   end

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -100,15 +100,31 @@ module GemDocs
 
     def initialize(shell_runner: nil)
       @loaded_gems = {}
+      @doc_sources = {}
       @shell_runner = shell_runner || method(:run_command)
     end
 
     def load_gem(name)
-      @loaded_gems.fetch(name) do
-        spec = self.class.gem_spec_for(name)
-        raise GemDocs::GemNotFound.new(name) unless spec
+      loaded_gem = @loaded_gems[name]
+      return loaded_gem if loaded_gem
 
-        @loaded_gems[name] = build_loaded_gem(spec)
+      spec = self.class.gem_spec_for(name)
+      raise GemDocs::GemNotFound.new(name) unless spec
+
+      loaded_gem = build_loaded_gem(spec)
+      @doc_sources[name] = loaded_gem.doc_source
+      @loaded_gems[name] = loaded_gem
+    end
+
+    def doc_source_for(name, spec: nil)
+      loaded_gem = @loaded_gems[name]
+      return loaded_gem.doc_source if loaded_gem
+
+      spec ||= self.class.gem_spec_for(name)
+      raise GemDocs::GemNotFound.new(name) unless spec
+
+      @doc_sources.fetch(name) do
+        @doc_sources[name] = detect_doc_source(spec)
       end
     end
 
@@ -123,9 +139,17 @@ module GemDocs
 
     private
 
+    def detect_doc_source(spec)
+      return :yard if File.exist?(yardoc_path_for(spec))
+      return :rdoc if rdoc_available?(spec)
+      return :source_only if source_objects_available?(spec)
+
+      :none
+    end
+
     def build_loaded_gem(spec)
-      loaded_gem = if File.exist?(File.join(spec.full_gem_path, ".yardoc"))
-        objects = load_yard_objects(File.join(spec.full_gem_path, ".yardoc"))
+      loaded_gem = if File.exist?(yardoc_path_for(spec))
+        objects = load_yard_objects(yardoc_path_for(spec))
         LoadedGem.new(
           name: spec.name,
           version: spec.version.to_s,
@@ -210,6 +234,21 @@ module GemDocs
       end
     end
 
+    def yardoc_path_for(spec)
+      File.join(spec.full_gem_path, ".yardoc")
+    end
+
+    def rdoc_available?(spec)
+      return false unless File.directory?(spec.doc_dir)
+
+      response = run_shell(*ri_list_command(spec))
+      return false if command_execution_failed?(response)
+
+      raise GemDocs::RegistryError.new("Failed to load ri registry: #{response[:stderr]}") unless response[:success]
+
+      response[:stdout].each_line.any? { |line| !line.strip.empty? }
+    end
+
     def build_rdoc_index_entry(name)
       Entry.new(
         path: name,
@@ -290,10 +329,41 @@ module GemDocs
       end
     end
 
+    def source_objects_available?(spec)
+      ruby_files_for(spec).any? do |file|
+        source_file_has_documentable_objects?(file)
+      end
+    end
+
     def ruby_files_for(spec)
       Array(spec.require_paths).flat_map do |require_path|
         Dir.glob(File.join(spec.full_gem_path, require_path, "**", "*.rb"))
       end.sort
+    end
+
+    def source_file_has_documentable_objects?(file)
+      stack = [ Prism.parse_file(file).value ]
+
+      until stack.empty?
+        node = stack.pop
+        return true if documentable_source_node?(node)
+        next unless node.respond_to?(:compact_child_nodes)
+
+        node.compact_child_nodes.each do |child|
+          stack << child
+        end
+      end
+
+      false
+    end
+
+    def documentable_source_node?(node)
+      case node
+      when Prism::ClassNode, Prism::ModuleNode, Prism::DefNode, Prism::ConstantWriteNode
+        true
+      else
+        false
+      end
     end
 
     def parse_source_file(file)

--- a/sig/deps/rubygems.rbs
+++ b/sig/deps/rubygems.rbs
@@ -5,6 +5,7 @@ module Gem
 
   class Specification
     def self.find_by_name: (String name) -> Specification
+    def self.to_a: -> Array[Specification]
 
     attr_reader name: String
     attr_reader version: Version

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -300,6 +300,12 @@ module GemDocs::Commands
 
   class List < Base
     def call: (**untyped) -> Integer
+
+    private
+
+    def installed_specs: -> Array[Gem::Specification]
+    def doc_registry: -> GemDocs::DocRegistry
+    def gem_payload: (Gem::Specification spec) -> Hash[Symbol, untyped]
   end
 
   class Lookup < Base

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -137,21 +137,28 @@ module GemDocs
 
     def initialize: (?shell_runner: ^(Array[String]) -> command_response) -> void
     def load_gem: (String name) -> LoadedGem
+    def doc_source_for: (String name, ?spec: Gem::Specification?) -> doc_source
     def find_object: (String path, gem_name: String) -> Entry?
     def classes_for: (String gem_name) -> Array[Entry]
 
     private
 
+    def detect_doc_source: (Gem::Specification spec) -> doc_source
     def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
     def load_yard_objects: (String yardoc) -> Array[Entry]
     def load_rdoc_objects: (Gem::Specification spec) -> Array[Entry]?
+    def yardoc_path_for: (Gem::Specification spec) -> String
+    def rdoc_available?: (Gem::Specification spec) -> bool
     def build_rdoc_index_entry: (String name) -> Entry
     def load_rdoc_object: (Gem::Specification spec, String path) -> Entry?
     def build_yard_namespace_entry: (YARD::CodeObjects::NamespaceObject object) -> Entry
     def build_yard_method_entry: (YARD::CodeObjects::MethodObject object) -> Entry
     def build_yard_constant_entry: (YARD::CodeObjects::ConstantObject object) -> Entry
     def load_source_objects: (Gem::Specification spec) -> Array[Entry]
+    def source_objects_available?: (Gem::Specification spec) -> bool
     def ruby_files_for: (Gem::Specification spec) -> Array[String]
+    def source_file_has_documentable_objects?: (String file) -> bool
+    def documentable_source_node?: (Prism::Node node) -> bool
     def parse_source_file: (String file) -> Array[Entry]
     def build_namespace_entry: (path: String, kind: :class | :module, file: String, line: Integer, ?superclass: String?) -> Entry
     def build_method_signature: (String namespace_path, Prism::DefNode node, class_method: bool) -> String

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe GemDocs::Commands::List do
           build_spec(name: "faraday", version: "2.12.0", summary: "HTTP/REST API client library.")
         ]
       )
-      allow(registry).to receive(:load_gem).with("faraday").and_return(
-        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
-      )
+      allow(registry).to receive(:doc_source_for).with("faraday", spec: anything).and_return(:yard)
 
       status = command.call(format: "json")
 
@@ -61,16 +59,11 @@ RSpec.describe GemDocs::Commands::List do
           build_spec(name: "source-only", version: "0.1.0", summary: "Fallback docs")
         ]
       )
-      allow(registry).to receive(:load_gem).with("faraday").and_return(
-        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
-      )
-      allow(registry).to receive(:load_gem).with("rake").and_return(
-        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :rdoc)
-      )
-      allow(registry).to receive(:load_gem).with("source-only").and_return(
-        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :source_only)
-      )
-      allow(registry).to receive(:load_gem).with("broken-gem").and_raise(GemDocs::RegistryError.new("boom"))
+      allow(registry).to receive(:doc_source_for).with("faraday", spec: anything).and_return(:yard)
+      allow(registry).to receive(:doc_source_for).with("rake", spec: anything).and_return(:rdoc)
+      allow(registry).to receive(:doc_source_for).with("source-only", spec: anything).and_return(:source_only)
+      allow(registry).to receive(:doc_source_for).with("broken-gem", spec: anything)
+        .and_raise(GemDocs::RegistryError.new("boom"))
 
       command.call(format: "json")
 
@@ -107,9 +100,7 @@ RSpec.describe GemDocs::Commands::List do
         ]
       )
       allow(command).to receive(:config).and_return(instance_double(GemDocs::Config, exclude_gems: [ "bundler" ]))
-      allow(registry).to receive(:load_gem).with("faraday").and_return(
-        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
-      )
+      allow(registry).to receive(:doc_source_for).with("faraday", spec: anything).and_return(:yard)
 
       command.call(format: "json")
 
@@ -124,6 +115,18 @@ RSpec.describe GemDocs::Commands::List do
         ]
       )
     end
+
+    it "does not swallow unexpected exceptions" do
+      allow(command).to receive(:installed_specs).and_return(
+        [
+          build_spec(name: "faraday", version: "2.12.0", summary: "HTTP/REST API client library.")
+        ]
+      )
+      allow(registry).to receive(:doc_source_for).with("faraday", spec: anything)
+        .and_raise(RuntimeError, "boom")
+
+      expect { command.call(format: "json") }.to raise_error(RuntimeError, "boom")
+    end
   end
 
   describe "--format text" do
@@ -134,12 +137,8 @@ RSpec.describe GemDocs::Commands::List do
           build_spec(name: "obscure-gem", version: "0.1.0", summary: "")
         ]
       )
-      allow(registry).to receive(:load_gem).with("faraday").and_return(
-        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
-      )
-      allow(registry).to receive(:load_gem).with("obscure-gem").and_return(
-        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :source_only)
-      )
+      allow(registry).to receive(:doc_source_for).with("faraday", spec: anything).and_return(:yard)
+      allow(registry).to receive(:doc_source_for).with("obscure-gem", spec: anything).and_return(:source_only)
 
       status = command.call(format: "text")
 

--- a/spec/commands/list_spec.rb
+++ b/spec/commands/list_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Commands::List do
+  def build_spec(name:, version:, summary:)
+    instance_double(
+      Gem::Specification,
+      name: name,
+      version: Gem::Version.new(version),
+      summary: summary
+    )
+  end
+
+  let(:stdout) { StringIO.new }
+  let(:command) { described_class.new }
+  let(:registry) { instance_double(GemDocs::DocRegistry) }
+  let(:config) { instance_double(GemDocs::Config, exclude_gems: []) }
+
+  before do
+    allow(command).to receive(:out).and_return(stdout)
+    allow(command).to receive(:config).and_return(config)
+    allow(command).to receive(:doc_registry).and_return(registry)
+  end
+
+  describe "--format json" do
+    it "outputs valid JSON to stdout" do
+      allow(command).to receive(:installed_specs).and_return(
+        [
+          build_spec(name: "faraday", version: "2.12.0", summary: "HTTP/REST API client library.")
+        ]
+      )
+      allow(registry).to receive(:load_gem).with("faraday").and_return(
+        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
+      )
+
+      status = command.call(format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to eq(
+        [
+          {
+            "name" => "faraday",
+            "version" => "2.12.0",
+            "doc_source" => "yard",
+            "summary" => "HTTP/REST API client library."
+          }
+        ]
+      )
+    end
+
+    it "includes the supported documentation sources for each gem" do
+      allow(command).to receive(:installed_specs).and_return(
+        [
+          build_spec(name: "broken-gem", version: "0.0.1", summary: ""),
+          build_spec(name: "faraday", version: "2.12.0", summary: "HTTP/REST API client library."),
+          build_spec(name: "rake", version: "13.2.1", summary: "Ruby build tool."),
+          build_spec(name: "source-only", version: "0.1.0", summary: "Fallback docs")
+        ]
+      )
+      allow(registry).to receive(:load_gem).with("faraday").and_return(
+        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
+      )
+      allow(registry).to receive(:load_gem).with("rake").and_return(
+        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :rdoc)
+      )
+      allow(registry).to receive(:load_gem).with("source-only").and_return(
+        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :source_only)
+      )
+      allow(registry).to receive(:load_gem).with("broken-gem").and_raise(GemDocs::RegistryError.new("boom"))
+
+      command.call(format: "json")
+
+      expect(JSON.parse(stdout.string)).to eq(
+        [
+          { "name" => "broken-gem", "version" => "0.0.1", "doc_source" => "none" },
+          {
+            "name" => "faraday",
+            "version" => "2.12.0",
+            "doc_source" => "yard",
+            "summary" => "HTTP/REST API client library."
+          },
+          {
+            "name" => "rake",
+            "version" => "13.2.1",
+            "doc_source" => "rdoc",
+            "summary" => "Ruby build tool."
+          },
+          {
+            "name" => "source-only",
+            "version" => "0.1.0",
+            "doc_source" => "source_only",
+            "summary" => "Fallback docs"
+          }
+        ]
+      )
+    end
+
+    it "excludes gems listed in configuration" do
+      allow(command).to receive(:installed_specs).and_return(
+        [
+          build_spec(name: "bundler", version: "2.5.9", summary: "Bundler"),
+          build_spec(name: "faraday", version: "2.12.0", summary: "HTTP/REST API client library.")
+        ]
+      )
+      allow(command).to receive(:config).and_return(instance_double(GemDocs::Config, exclude_gems: [ "bundler" ]))
+      allow(registry).to receive(:load_gem).with("faraday").and_return(
+        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
+      )
+
+      command.call(format: "json")
+
+      expect(JSON.parse(stdout.string)).to eq(
+        [
+          {
+            "name" => "faraday",
+            "version" => "2.12.0",
+            "doc_source" => "yard",
+            "summary" => "HTTP/REST API client library."
+          }
+        ]
+      )
+    end
+  end
+
+  describe "--format text" do
+    it "outputs a human-readable aligned table" do
+      allow(command).to receive(:installed_specs).and_return(
+        [
+          build_spec(name: "faraday", version: "2.12.0", summary: "HTTP/REST API client library."),
+          build_spec(name: "obscure-gem", version: "0.1.0", summary: "")
+        ]
+      )
+      allow(registry).to receive(:load_gem).with("faraday").and_return(
+        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :yard)
+      )
+      allow(registry).to receive(:load_gem).with("obscure-gem").and_return(
+        instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :source_only)
+      )
+
+      status = command.call(format: "text")
+
+      expect(status).to eq(0)
+      expect(stdout.string.lines).to eq(
+        [
+          "NAME         VERSION  DOC SOURCE   SUMMARY\n",
+          "faraday      2.12.0   yard         HTTP/REST API client library.\n",
+          "obscure-gem  0.1.0    source_only\n"
+        ]
+      )
+    end
+  end
+end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -230,6 +230,62 @@ RSpec.describe GemDocs::DocRegistry do
     end
   end
 
+  describe "#doc_source_for" do
+    it "returns :yard when a gem has a .yardoc registry" do
+      with_yard_fixture_gem("well_documented", source: "module WellDocumented; end\n") do
+        registry = described_class.new
+
+        expect(registry.doc_source_for("well_documented")).to eq(:yard)
+      end
+    end
+
+    it "uses ri index availability without loading ri objects" do
+      with_source_fixture_gem("rdoc_only", source: "# intentionally empty\n") do |spec|
+        FileUtils.mkdir_p(spec.doc_dir)
+        commands = []
+
+        shell_runner = lambda do |command|
+          commands << command
+
+          case command.last
+          when "-l"
+            { stdout: "RdocOnly::Widget\n", stderr: "", success: true }
+          else
+            raise "unexpected command: #{command.inspect}"
+          end
+        end
+
+        registry = described_class.new(shell_runner: shell_runner)
+
+        expect(registry.doc_source_for("rdoc_only")).to eq(:rdoc)
+        expect(commands).to eq([ [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "-l" ] ])
+      end
+    end
+
+    it "returns :source_only when Ruby source defines documentable objects" do
+      with_source_fixture_gem("source_only", source: <<~RUBY) do
+        module SourceOnly
+          class Widget
+            def call
+            end
+          end
+        end
+      RUBY
+        registry = described_class.new
+
+        expect(registry.doc_source_for("source_only")).to eq(:source_only)
+      end
+    end
+
+    it "returns :none when Ruby files do not define documentable objects" do
+      with_source_fixture_gem("empty_source", source: "# intentionally empty\n") do
+        registry = described_class.new
+
+        expect(registry.doc_source_for("empty_source")).to eq(:none)
+      end
+    end
+  end
+
   describe "#find_object" do
     it "walks inherited namespaces to resolve inherited instance methods" do
       with_source_fixture_gem("inheritance_fixture", source: <<~RUBY) do


### PR DESCRIPTION
## Summary
- implement gem-docs list with text and JSON output
- respect configured excluded gems and degrade broken registry loads to none
- add command coverage and type signatures for the new listing flow

Closes #6

## Test Plan
- bundle exec rubocop
- bundle exec steep check
- bundle exec rspec