### PR TITLE
feat: add gem summary command

### DIFF
--- a/lib/gem_docs/commands/summary.rb
+++ b/lib/gem_docs/commands/summary.rb
@@ -4,9 +4,31 @@ module GemDocs
   module Commands
     class Summary < Base
       desc "Summarize a gem"
+      argument :gem_name, type: :string
+      option :version, values: [], default: "", desc: "Gem version"
 
-      def call(**_kwargs)
-        placeholder("summary")
+      def call(gem_name:, version: nil, format: "text", **_kwargs)
+        out.puts GemDocs::Formatters.for(format).summary(gem: summary_payload(doc_registry.load_gem(gem_name, version: version)))
+        0
+      end
+
+      private
+
+      def doc_registry
+        @doc_registry ||= GemDocs::DocRegistry.new
+      end
+
+      def summary_payload(loaded_gem)
+        {
+          name: loaded_gem.name,
+          version: loaded_gem.version,
+          description: loaded_gem.description.to_s.empty? ? loaded_gem.summary : loaded_gem.description,
+          homepage: loaded_gem.homepage,
+          license: loaded_gem.license,
+          doc_source: loaded_gem.doc_source,
+          classes: loaded_gem.classes.sort_by(&:path).map(&:path),
+          entry_points: loaded_gem.entry_points
+        }
       end
     end
   end

--- a/lib/gem_docs/commands/summary.rb
+++ b/lib/gem_docs/commands/summary.rb
@@ -5,7 +5,7 @@ module GemDocs
     class Summary < Base
       desc "Summarize a gem"
       argument :gem_name, type: :string
-      option :version, values: [], default: "", desc: "Gem version"
+      option :version, desc: "Gem version"
 
       def call(gem_name:, version: nil, format: "text", **_kwargs)
         out.puts GemDocs::Formatters.for(format).summary(gem: summary_payload(doc_registry.load_gem(gem_name, version: version)))

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -29,15 +29,33 @@ module GemDocs
       MISSING = Object.new
       private_constant :MISSING
 
-      attr_reader :name, :version, :summary, :path, :doc_source, :objects
+      attr_reader :name, :version, :summary, :description, :homepage, :license, :path, :doc_source, :objects,
+                  :entry_points
 
-      def initialize(name:, version:, summary:, path:, doc_source:, objects:, dynamic_lookup: nil, lazy_paths: [])
+      def initialize(
+        name:,
+        version:,
+        summary:,
+        path:,
+        doc_source:,
+        objects:,
+        description: nil,
+        homepage: nil,
+        license: nil,
+        entry_points: [],
+        dynamic_lookup: nil,
+        lazy_paths: []
+      )
         @name = name
         @version = version
         @summary = summary
+        @description = description
+        @homepage = homepage
+        @license = license
         @path = path
         @doc_source = doc_source
         @objects = objects.dup
+        @entry_points = entry_points.dup
         @dynamic_lookup = dynamic_lookup
         @lazy_paths = lazy_paths.each_with_object({}) do |lazy_path, pending|
           pending[lazy_path] = true
@@ -91,8 +109,10 @@ module GemDocs
     end
 
     class << self
-      def gem_spec_for(name)
-        Gem::Specification.find_by_name(name)
+      def gem_spec_for(name, version: nil)
+        return Gem::Specification.find_by_name(name) if version.nil? || version.empty?
+
+        Gem::Specification.find_by_name(name, version)
       rescue Gem::LoadError
         nil
       end
@@ -104,16 +124,21 @@ module GemDocs
       @shell_runner = shell_runner || method(:run_command)
     end
 
-    def load_gem(name)
-      loaded_gem = @loaded_gems[name]
+    def load_gem(name, version: nil)
+      cache_key = version.nil? || version.empty? ? name : [ name, version ].freeze
+      loaded_gem = @loaded_gems[cache_key]
       return loaded_gem if loaded_gem
 
-      spec = self.class.gem_spec_for(name)
+      spec = if version.nil? || version.empty?
+        self.class.gem_spec_for(name)
+      else
+        self.class.gem_spec_for(name, version: version)
+      end
       raise GemDocs::GemNotFound.new(name) unless spec
 
       loaded_gem = build_loaded_gem(spec)
       @doc_sources[name] = loaded_gem.doc_source
-      @loaded_gems[name] = loaded_gem
+      @loaded_gems[cache_key] = loaded_gem
     end
 
     def doc_source_for(name, spec: nil)
@@ -154,18 +179,26 @@ module GemDocs
           name: spec.name,
           version: spec.version.to_s,
           summary: spec.summary,
+          description: gem_description(spec),
+          homepage: spec.homepage,
+          license: gem_license(spec),
           path: spec.full_gem_path,
           doc_source: :yard,
-          objects: objects
+          objects: objects,
+          entry_points: infer_entry_points(spec.name, objects, doc_source: :yard)
         )
       elsif (rdoc_objects = load_rdoc_objects(spec))
         LoadedGem.new(
           name: spec.name,
           version: spec.version.to_s,
           summary: spec.summary,
+          description: gem_description(spec),
+          homepage: spec.homepage,
+          license: gem_license(spec),
           path: spec.full_gem_path,
           doc_source: :rdoc,
           objects: rdoc_objects,
+          entry_points: infer_entry_points(spec.name, rdoc_objects, doc_source: :rdoc),
           dynamic_lookup: ->(path) { load_rdoc_object(spec, path) },
           lazy_paths: rdoc_objects.map(&:path)
         )
@@ -175,9 +208,13 @@ module GemDocs
           name: spec.name,
           version: spec.version.to_s,
           summary: spec.summary,
+          description: gem_description(spec),
+          homepage: spec.homepage,
+          license: gem_license(spec),
           path: spec.full_gem_path,
           doc_source: objects.empty? ? :none : :source_only,
-          objects: objects
+          objects: objects,
+          entry_points: infer_entry_points(spec.name, objects, doc_source: objects.empty? ? :none : :source_only)
         )
       end
 
@@ -216,6 +253,49 @@ module GemDocs
       end
     rescue StandardError => e
       raise GemDocs::RegistryError.new("Failed to load YARD registry: #{e.message}")
+    end
+
+    def gem_description(spec)
+      description = spec.description.to_s.strip
+      return description unless description.empty?
+
+      spec.summary
+    end
+
+    def gem_license(spec)
+      licenses = Array(spec.licenses).filter_map do |value|
+        normalized = value.to_s.strip
+        normalized unless normalized.empty?
+      end
+      return licenses.first unless licenses.empty?
+
+      license = spec.respond_to?(:license) ? spec.license.to_s.strip : ""
+      license.empty? ? nil : license
+    end
+
+    def infer_entry_points(gem_name, objects, doc_source:)
+      return [] if doc_source == :source_only || doc_source == :none
+
+      classes = objects.select(&:class_or_module?).sort_by(&:path)
+      methods = objects.select do |object|
+        [ :class_method, :instance_method ].include?(object.kind) && object.visibility == :public
+      end.sort_by(&:path)
+
+      entry_points = []
+      primary_class = select_primary_class(classes, gem_name)
+      entry_points << "#{primary_class.path}.new" if primary_class&.kind == :class
+      entry_points.concat(methods.reject { |object| object.name == "initialize" }.map(&:path))
+      entry_points.uniq.first(3)
+    end
+
+    def select_primary_class(classes, gem_name)
+      namespace = gem_name.split(/[^a-zA-Z0-9]+/).reject(&:empty?).map(&:capitalize).join
+
+      classes.find { |entry| entry.kind == :class && entry.path == namespace } ||
+        classes.find { |entry| entry.kind == :class && !entry.path.include?("::") } ||
+        classes.find { |entry| entry.kind == :module && entry.path == namespace } ||
+        classes.find { |entry| !entry.path.include?("::") } ||
+        classes.first
     end
 
     def load_rdoc_objects(spec)

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -125,31 +125,39 @@ module GemDocs
     end
 
     def load_gem(name, version: nil)
-      cache_key = version.nil? || version.empty? ? name : [ name, version ].freeze
+      cache_key = cache_key_for(name, version)
       loaded_gem = @loaded_gems[cache_key]
       return loaded_gem if loaded_gem
 
-      spec = if version.nil? || version.empty?
+      normalized_version = normalize_version(version)
+
+      spec = if normalized_version.nil?
         self.class.gem_spec_for(name)
       else
-        self.class.gem_spec_for(name, version: version)
+        self.class.gem_spec_for(name, version: normalized_version)
       end
       raise GemDocs::GemNotFound.new(name) unless spec
 
       loaded_gem = build_loaded_gem(spec)
-      @doc_sources[name] = loaded_gem.doc_source
+      @doc_sources[cache_key] = loaded_gem.doc_source
       @loaded_gems[cache_key] = loaded_gem
     end
 
-    def doc_source_for(name, spec: nil)
-      loaded_gem = @loaded_gems[name]
+    def doc_source_for(name, version: nil, spec: nil)
+      cache_key = cache_key_for(name, version || spec&.version&.to_s)
+      loaded_gem = @loaded_gems[cache_key]
       return loaded_gem.doc_source if loaded_gem
 
-      spec ||= self.class.gem_spec_for(name)
+      normalized_version = normalize_version(version)
+      spec ||= if normalized_version.nil?
+        self.class.gem_spec_for(name)
+      else
+        self.class.gem_spec_for(name, version: normalized_version)
+      end
       raise GemDocs::GemNotFound.new(name) unless spec
 
-      @doc_sources.fetch(name) do
-        @doc_sources[name] = detect_doc_source(spec)
+      @doc_sources.fetch(cache_key) do
+        @doc_sources[cache_key] = detect_doc_source(spec)
       end
     end
 
@@ -170,6 +178,19 @@ module GemDocs
       return :source_only if source_objects_available?(spec)
 
       :none
+    end
+
+    def cache_key_for(name, version)
+      normalized_version = normalize_version(version)
+      return name if normalized_version.nil?
+
+      [ name, normalized_version ].freeze
+    end
+
+    def normalize_version(version)
+      return nil if version.nil? || version.empty?
+
+      version
     end
 
     def build_loaded_gem(spec)

--- a/lib/gem_docs/formatters/base.rb
+++ b/lib/gem_docs/formatters/base.rb
@@ -14,9 +14,13 @@ module GemDocs
             name: gem.name,
             version: gem.version,
             summary: gem.summary,
+            description: gem.description,
+            homepage: gem.homepage,
+            license: gem.license,
             path: gem.path,
             doc_source: gem.doc_source,
-            classes: gem.classes.map(&:path)
+            classes: gem.classes.map(&:path),
+            entry_points: gem.entry_points
           )
         else
           compact_hash(gem.to_h)

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -18,7 +18,20 @@ module GemDocs
       end
 
       def summary(gem:)
-        call(compact_value(normalize_gem(gem)))
+        normalized_gem = normalize_gem(gem)
+        payload = {
+          name: normalized_gem.fetch(:name),
+          version: normalized_gem.fetch(:version),
+          doc_source: normalized_gem.fetch(:doc_source).to_s,
+          classes: Array(normalized_gem[:classes]),
+          entry_points: Array(normalized_gem[:entry_points])
+        }
+        description = normalized_gem[:description] || normalized_gem[:summary]
+        payload[:description] = description if description && !description.empty?
+        payload[:homepage] = normalized_gem[:homepage] if normalized_gem[:homepage] && !normalized_gem[:homepage].empty?
+        payload[:license] = normalized_gem[:license] if normalized_gem[:license] && !normalized_gem[:license].empty?
+
+        call(payload)
       end
 
       def classes(gem:, entries:)

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -40,13 +40,15 @@ module GemDocs
 
       def summary(gem:)
         normalized_gem = normalize_gem(gem)
+        entry_points = Array(normalized_gem[:entry_points])
 
         build_sections(
-          "#{normalized_gem.fetch(:name)} (#{normalized_gem.fetch(:version)})",
-          normalized_gem[:summary],
-          "Documentation: #{normalized_gem[:doc_source]}",
+          "#{normalized_gem.fetch(:name)} #{normalized_gem.fetch(:version)} [#{normalized_gem.fetch(:doc_source)}]",
+          normalized_gem[:description] || normalized_gem[:summary],
+          normalized_gem[:homepage],
+          normalized_gem[:license] ? "License: #{normalized_gem[:license]}" : nil,
           section("Classes", normalized_gem[:classes]),
-          section("Entry points", normalized_gem[:entry_points])
+          entry_points.empty? ? "Entry points: none documented" : build_sections("Entry points:", *entry_points.map { |entry| "  #{entry}" })
         )
       end
 

--- a/sig/deps/dry_cli.rbs
+++ b/sig/deps/dry_cli.rbs
@@ -17,7 +17,7 @@ module Dry
     def self.desc: (String description) -> void
     def self.example: (Array[String] examples) -> void
     def self.argument: (Symbol name, type: Symbol) -> void
-    def self.option: (Symbol name, values: Array[String], default: String, desc: String) -> void
+    def self.option: (Symbol name, ?values: Array[String]?, ?default: String?, desc: String) -> void
     def self.description: -> String?
     def self.examples: -> Array[String]
 

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -145,13 +145,15 @@ module GemDocs
 
     def initialize: (?shell_runner: ^(Array[String]) -> command_response) -> void
     def load_gem: (String name, ?version: String?) -> LoadedGem
-    def doc_source_for: (String name, ?spec: Gem::Specification?) -> doc_source
+    def doc_source_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> doc_source
     def find_object: (String path, gem_name: String) -> Entry?
     def classes_for: (String gem_name) -> Array[Entry]
 
     private
 
     def detect_doc_source: (Gem::Specification spec) -> doc_source
+    def cache_key_for: (String name, String? version) -> (String | [String, String])
+    def normalize_version: (String? version) -> String?
     def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
     def load_yard_objects: (String yardoc) -> Array[Entry]
     def gem_description: (Gem::Specification spec) -> String?

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -110,17 +110,25 @@ module GemDocs
       attr_reader name: String
       attr_reader version: String
       attr_reader summary: String?
+      attr_reader description: String?
+      attr_reader homepage: String?
+      attr_reader license: String?
       attr_reader path: String
       attr_reader doc_source: doc_source
       attr_reader objects: Array[Entry]
+      attr_reader entry_points: Array[String]
 
       def initialize: (
         name: String,
         version: String,
         summary: String?,
+        ?description: String?,
+        ?homepage: String?,
+        ?license: String?,
         path: String,
         doc_source: doc_source,
         objects: Array[Entry],
+        ?entry_points: Array[String],
         ?dynamic_lookup: ^(String) -> Entry?,
         ?lazy_paths: Array[String]
       ) -> void
@@ -133,10 +141,10 @@ module GemDocs
       def replace_object: (String path, Entry object) -> Array[Entry]
     end
 
-    def self.gem_spec_for: (String name) -> Gem::Specification?
+    def self.gem_spec_for: (String name, ?version: String?) -> Gem::Specification?
 
     def initialize: (?shell_runner: ^(Array[String]) -> command_response) -> void
-    def load_gem: (String name) -> LoadedGem
+    def load_gem: (String name, ?version: String?) -> LoadedGem
     def doc_source_for: (String name, ?spec: Gem::Specification?) -> doc_source
     def find_object: (String path, gem_name: String) -> Entry?
     def classes_for: (String gem_name) -> Array[Entry]
@@ -146,6 +154,10 @@ module GemDocs
     def detect_doc_source: (Gem::Specification spec) -> doc_source
     def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
     def load_yard_objects: (String yardoc) -> Array[Entry]
+    def gem_description: (Gem::Specification spec) -> String?
+    def gem_license: (Gem::Specification spec) -> String?
+    def infer_entry_points: (String gem_name, Array[Entry] objects, doc_source: doc_source) -> Array[String]
+    def select_primary_class: (Array[Entry] classes, String gem_name) -> Entry?
     def load_rdoc_objects: (Gem::Specification spec) -> Array[Entry]?
     def yardoc_path_for: (Gem::Specification spec) -> String
     def rdoc_available?: (Gem::Specification spec) -> bool
@@ -324,7 +336,12 @@ module GemDocs::Commands
   end
 
   class Summary < Base
-    def call: (**untyped) -> Integer
+    def call: (gem_name: String, ?version: String?, ?format: String, **untyped) -> Integer
+
+    private
+
+    def doc_registry: -> GemDocs::DocRegistry
+    def summary_payload: (GemDocs::DocRegistry::LoadedGem loaded_gem) -> Hash[Symbol, untyped]
   end
 
   class Server < Base

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -102,4 +102,26 @@ RSpec.describe GemDocs::CLI do
       "message" => "Gem 'missing-gem' is not installed"
     )
   end
+
+  it "accepts --version for the summary command" do
+    registry = instance_double(
+      GemDocs::DocRegistry,
+      load_gem: GemDocs::DocRegistry::LoadedGem.new(
+        name: "faraday",
+        version: "2.12.0",
+        summary: "HTTP client",
+        description: "HTTP client",
+        path: "/tmp/faraday",
+        doc_source: :yard,
+        objects: []
+      )
+    )
+    allow(GemDocs::DocRegistry).to receive(:new).and_return(registry)
+
+    status = described_class.start([ "summary", "faraday", "--version", "2.12.0" ], out: stdout, err: stderr)
+
+    expect(status).to eq(0)
+    expect(stderr.string).to eq("")
+    expect(registry).to have_received(:load_gem).with("faraday", version: "2.12.0")
+  end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -83,4 +83,23 @@ RSpec.describe GemDocs::CLI do
       "message" => "Documentation is unavailable for 'missing-gem'"
     )
   end
+
+  it "renders structured JSON errors for summary lookup failures" do
+    stub_const("GemDocs::Commands::Summary", Class.new(GemDocs::Commands::Base) do
+      desc "Summarize a gem"
+
+      def call(**)
+        raise GemDocs::GemNotFound.new("missing-gem")
+      end
+    end)
+
+    status = described_class.start([ "summary", "missing-gem", "--format", "json" ], out: stdout, err: stderr)
+
+    expect(status).to eq(1)
+    expect(stdout.string).to eq("")
+    expect(JSON.parse(stderr.string)).to eq(
+      "error" => "not_found",
+      "message" => "Gem 'missing-gem' is not installed"
+    )
+  end
 end

--- a/spec/commands/summary_spec.rb
+++ b/spec/commands/summary_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Commands::Summary do
+  def build_entry(path:, kind: :class)
+    GemDocs::DocRegistry::Entry.new(
+      path: path,
+      name: path.split(/[:#.]/).last,
+      kind: kind,
+      visibility: :public,
+      docstring: "",
+      signature: path,
+      source_location: nil,
+      superclass: nil,
+      doc_source: :yard
+    )
+  end
+
+  def build_loaded_gem(
+    name:,
+    version:,
+    summary:,
+    description: summary,
+    homepage: nil,
+    license: nil,
+    doc_source:,
+    entry_points: [],
+    objects:
+  )
+    GemDocs::DocRegistry::LoadedGem.new(
+      name: name,
+      version: version,
+      summary: summary,
+      description: description,
+      homepage: homepage,
+      license: license,
+      path: "/tmp/#{name}",
+      doc_source: doc_source,
+      objects: objects,
+      entry_points: entry_points
+    )
+  end
+
+  let(:stdout) { StringIO.new }
+  let(:command) { described_class.new }
+  let(:registry) { instance_double(GemDocs::DocRegistry) }
+
+  before do
+    allow(command).to receive(:out).and_return(stdout)
+    allow(command).to receive(:doc_registry).and_return(registry)
+  end
+
+  it "outputs the documented JSON summary for a requested gem version" do
+    allow(registry).to receive(:load_gem).with("faraday", version: "2.12.0").and_return(
+      build_loaded_gem(
+        name: "faraday",
+        version: "2.12.0",
+        summary: "HTTP/REST API client library for Ruby.",
+        homepage: "https://github.com/lostisland/faraday",
+        license: "MIT",
+        doc_source: :yard,
+        entry_points: [ "Faraday.new", "Faraday::Connection#get" ],
+        objects: [
+          build_entry(path: "Faraday"),
+          build_entry(path: "Faraday::Connection"),
+          build_entry(path: "Faraday::Response")
+        ]
+      )
+    )
+
+    status = command.call(gem_name: "faraday", version: "2.12.0", format: "json")
+
+    expect(status).to eq(0)
+    expect(JSON.parse(stdout.string)).to eq(
+      "name" => "faraday",
+      "version" => "2.12.0",
+      "description" => "HTTP/REST API client library for Ruby.",
+      "homepage" => "https://github.com/lostisland/faraday",
+      "license" => "MIT",
+      "doc_source" => "yard",
+      "classes" => [ "Faraday", "Faraday::Connection", "Faraday::Response" ],
+      "entry_points" => [ "Faraday.new", "Faraday::Connection#get" ]
+    )
+  end
+
+  it "renders a readable text summary with entry points" do
+    allow(registry).to receive(:load_gem).with("faraday", version: nil).and_return(
+      build_loaded_gem(
+        name: "faraday",
+        version: "2.12.0",
+        summary: "HTTP/REST API client library for Ruby.",
+        homepage: "https://github.com/lostisland/faraday",
+        license: "MIT",
+        doc_source: :yard,
+        entry_points: [ "Faraday.new", "Faraday::Connection#get" ],
+        objects: [
+          build_entry(path: "Faraday"),
+          build_entry(path: "Faraday::Connection")
+        ]
+      )
+    )
+
+    status = command.call(gem_name: "faraday", format: "text")
+
+    expect(status).to eq(0)
+    expect(stdout.string).to eq(
+      "faraday 2.12.0 [yard]\n" \
+      "HTTP/REST API client library for Ruby.\n" \
+      "https://github.com/lostisland/faraday\n" \
+      "License: MIT\n" \
+      "Classes: Faraday, Faraday::Connection\n" \
+      "Entry points:\n" \
+      "  Faraday.new\n" \
+      "  Faraday::Connection#get\n"
+    )
+  end
+
+  it "preserves empty entry points for source-only gems in JSON output" do
+    allow(registry).to receive(:load_gem).with("source-only", version: nil).and_return(
+      build_loaded_gem(
+        name: "source-only",
+        version: "0.1.0",
+        summary: "Fallback docs",
+        doc_source: :source_only,
+        objects: [ build_entry(path: "SourceOnly::Widget") ]
+      )
+    )
+
+    command.call(gem_name: "source-only", format: "json")
+
+    expect(JSON.parse(stdout.string)).to include(
+      "name" => "source-only",
+      "doc_source" => "source_only",
+      "classes" => [ "SourceOnly::Widget" ],
+      "entry_points" => []
+    )
+  end
+end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -7,10 +7,10 @@ require "spec_helper"
 require "gem_docs"
 
 RSpec.describe GemDocs::DocRegistry do
-  def build_fixture_spec(name, gem_root:, summary: "Fixture gem")
+  def build_fixture_spec(name, gem_root:, summary: "Fixture gem", version: "0.1.0")
     Gem::Specification.new do |spec|
       spec.name = name
-      spec.version = "0.1.0"
+      spec.version = version
       spec.summary = summary
       spec.files = Dir.chdir(gem_root) { Dir["lib/**/*.rb"] }
       spec.require_paths = [ "lib" ]
@@ -85,6 +85,7 @@ RSpec.describe GemDocs::DocRegistry do
         loaded_gem = registry.load_gem("source_only")
 
         expect(loaded_gem.doc_source).to eq(:source_only)
+        expect(loaded_gem.entry_points).to eq([])
         expect(registry.find_object("SourceOnly::Widget#call", gem_name: "source_only")&.signature)
           .to eq("SourceOnly::Widget#call(input)")
       end
@@ -110,8 +111,23 @@ RSpec.describe GemDocs::DocRegistry do
 
         expect(first_load.doc_source).to eq(:yard)
         expect(second_load).to equal(first_load)
+        expect(first_load.entry_points).to include("WellDocumented::Widget#call")
         expect(registry.find_object("WellDocumented::Widget#call", gem_name: "well_documented")&.docstring)
           .to include("Performs work.")
+      end
+    end
+
+    it "loads a requested gem version when provided" do
+      Dir.mktmpdir do |tmpdir|
+        gem_root = File.join(tmpdir, "versioned-gem")
+        FileUtils.mkdir_p(File.join(gem_root, "lib"))
+        spec = build_fixture_spec("versioned-gem", gem_root: gem_root, version: "1.2.3")
+
+        allow(described_class).to receive(:gem_spec_for).with("versioned-gem", version: "1.2.3").and_return(spec)
+
+        registry = described_class.new
+
+        expect(registry.load_gem("versioned-gem", version: "1.2.3").version).to eq("1.2.3")
       end
     end
 

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -247,6 +247,39 @@ RSpec.describe GemDocs::DocRegistry do
   end
 
   describe "#doc_source_for" do
+    it "reuses cached versioned loads for doc source lookups" do
+      Dir.mktmpdir do |tmpdir|
+        gem_root = File.join(tmpdir, "versioned-gem")
+        FileUtils.mkdir_p(File.join(gem_root, "lib"))
+        File.write(File.join(gem_root, "lib", "versioned-gem.rb"), "module VersionedGem; end\n")
+        spec = build_fixture_spec("versioned-gem", gem_root: gem_root, version: "1.2.3")
+
+        expect(described_class).to receive(:gem_spec_for).with("versioned-gem", version: "1.2.3").once.and_return(spec)
+
+        registry = described_class.new
+        registry.load_gem("versioned-gem", version: "1.2.3")
+
+        expect(registry.doc_source_for("versioned-gem", version: "1.2.3")).to eq(:source_only)
+      end
+    end
+
+    it "keeps cached doc sources separate for different gem versions" do
+      Dir.mktmpdir do |tmpdir|
+        first_root = File.join(tmpdir, "multi-version-1")
+        second_root = File.join(tmpdir, "multi-version-2")
+        FileUtils.mkdir_p(first_root)
+        FileUtils.mkdir_p(File.join(second_root, "lib"))
+        File.write(File.join(second_root, "lib", "multi-version.rb"), "module MultiVersion; end\n")
+
+        first_spec = build_fixture_spec("multi-version", gem_root: first_root, version: "1.0.0")
+        second_spec = build_fixture_spec("multi-version", gem_root: second_root, version: "2.0.0")
+        registry = described_class.new
+
+        expect(registry.doc_source_for("multi-version", version: "1.0.0", spec: first_spec)).to eq(:none)
+        expect(registry.doc_source_for("multi-version", version: "2.0.0", spec: second_spec)).to eq(:source_only)
+      end
+    end
+
     it "returns :yard when a gem has a .yardoc registry" do
       with_yard_fixture_gem("well_documented", source: "module WellDocumented; end\n") do
         registry = described_class.new

--- a/spec/formatters/json_spec.rb
+++ b/spec/formatters/json_spec.rb
@@ -19,14 +19,17 @@ RSpec.describe GemDocs::Formatters::Json do
     )
   end
 
-  def build_loaded_gem(name:, version:, summary:, doc_source:, objects:)
+  def build_loaded_gem(name:, version:, summary:, doc_source:, objects:, homepage: nil, license: nil, entry_points: [])
     GemDocs::DocRegistry::LoadedGem.new(
       name: name,
       version: version,
       summary: summary,
+      homepage: homepage,
+      license: license,
       path: "/tmp/#{name}",
       doc_source: doc_source,
-      objects: objects
+      objects: objects,
+      entry_points: entry_points
     )
   end
 
@@ -90,7 +93,10 @@ RSpec.describe GemDocs::Formatters::Json do
         name: "rack",
         version: "3.1.0",
         summary: "HTTP toolkit",
+        homepage: "https://example.test/rack",
+        license: "MIT",
         doc_source: :yard,
+        entry_points: [ "Rack.new" ],
         objects: [
           build_entry(path: "Rack::Builder"),
           build_entry(path: "Rack::Request")
@@ -102,10 +108,30 @@ RSpec.describe GemDocs::Formatters::Json do
       expect(JSON.parse(output)).to eq(
         "name" => "rack",
         "version" => "3.1.0",
-        "summary" => "HTTP toolkit",
-        "path" => "/tmp/rack",
+        "description" => "HTTP toolkit",
+        "homepage" => "https://example.test/rack",
+        "license" => "MIT",
         "doc_source" => "yard",
-        "classes" => [ "Rack::Builder", "Rack::Request" ]
+        "classes" => [ "Rack::Builder", "Rack::Request" ],
+        "entry_points" => [ "Rack.new" ]
+      )
+    end
+
+    it "preserves empty entry points for source-only gems" do
+      formatter = described_class.new
+      loaded_gem = build_loaded_gem(
+        name: "source-only",
+        version: "0.1.0",
+        summary: "Fallback docs",
+        doc_source: :source_only,
+        objects: [ build_entry(path: "SourceOnly::Widget") ]
+      )
+
+      output = formatter.summary(gem: loaded_gem)
+
+      expect(JSON.parse(output)).to include(
+        "name" => "source-only",
+        "entry_points" => []
       )
     end
   end

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -18,14 +18,17 @@ RSpec.describe GemDocs::Formatters::Text do
     )
   end
 
-  def build_loaded_gem(name:, version:, summary:, doc_source:, objects:)
+  def build_loaded_gem(name:, version:, summary:, doc_source:, objects:, homepage: nil, license: nil, entry_points: [])
     GemDocs::DocRegistry::LoadedGem.new(
       name: name,
       version: version,
       summary: summary,
+      homepage: homepage,
+      license: license,
       path: "/tmp/#{name}",
       doc_source: doc_source,
-      objects: objects
+      objects: objects,
+      entry_points: entry_points
     )
   end
 
@@ -58,6 +61,7 @@ RSpec.describe GemDocs::Formatters::Text do
         version: "3.1.0",
         summary: "HTTP toolkit",
         doc_source: :yard,
+        entry_points: [ "Rack.new", "Rack::Builder#call" ],
         objects: [
           build_entry(path: "Rack::Builder"),
           build_entry(path: "Rack::Request")
@@ -67,10 +71,12 @@ RSpec.describe GemDocs::Formatters::Text do
       output = formatter.summary(gem: loaded_gem)
 
       expect(output).to eq(
-        "rack (3.1.0)\n" \
+        "rack 3.1.0 [yard]\n" \
         "HTTP toolkit\n" \
-        "Documentation: yard\n" \
-        "Classes: Rack::Builder, Rack::Request"
+        "Classes: Rack::Builder, Rack::Request\n" \
+        "Entry points:\n" \
+        "  Rack.new\n" \
+        "  Rack::Builder#call"
       )
     end
   end


### PR DESCRIPTION
## Summary
- implement `gem-docs summary <gem> [--version <ver>]` with text and JSON output
- include gem metadata, classes, and inferred entry points while preserving empty entry point arrays for source-only gems
- add command, formatter, registry, CLI, and type/spec coverage for summary behavior

Closes #7

## Test plan
- bundle exec rubocop -a
- bundle exec steep check
- bundle exec rspec

Generated with GitHub Copilot CLI.