### PR TITLE
feat: add gem-docs classes command

### DIFF
--- a/lib/gem_docs/commands/classes.rb
+++ b/lib/gem_docs/commands/classes.rb
@@ -3,10 +3,65 @@
 module GemDocs
   module Commands
     class Classes < Base
-      desc "List documented classes"
+      desc "List documented classes and modules"
+      argument :gem_name, type: :string
+      option :version, desc: "Gem version"
 
-      def call(**_kwargs)
-        placeholder("classes")
+      def call(gem_name:, version: nil, format: "text", **_kwargs)
+        loaded_gem = doc_registry.load_gem(gem_name, version: version)
+        out.puts GemDocs::Formatters.for(format).classes(gem: gem_name, entries: class_payloads(loaded_gem))
+        0
+      end
+
+      private
+
+      def doc_registry
+        @doc_registry ||= GemDocs::DocRegistry.new
+      end
+
+      def class_payloads(loaded_gem)
+        loaded_gem.classes
+          .select { |entry| visible_named_entry?(entry) }
+          .sort_by(&:path)
+          .map do |entry|
+            {
+              name: entry.path,
+              type: entry.kind.to_s,
+              superclass: class_superclass(entry),
+              summary: summary_for(entry),
+              method_count: method_count_for(loaded_gem, entry)
+            }
+          end
+      end
+
+      def visible_named_entry?(entry)
+        entry.visibility == :public && !anonymous_entry?(entry)
+      end
+
+      def anonymous_entry?(entry)
+        path = entry.path.to_s.strip
+        path.empty? || path.include?("#<")
+      end
+
+      def class_superclass(entry)
+        return unless entry.kind == :class
+        return entry.superclass unless entry.superclass.to_s.empty?
+        return if entry.path == "BasicObject"
+
+        "Object"
+      end
+
+      def summary_for(entry)
+        entry.docstring.to_s.lines.map(&:strip).reject(&:empty?).first.to_s
+      end
+
+      def method_count_for(loaded_gem, entry)
+        loaded_gem.objects.count do |object|
+          next false unless [ :class_method, :instance_method ].include?(object.kind)
+          next false unless object.visibility == :public
+
+          object.path.start_with?("#{entry.path}#", "#{entry.path}.")
+        end
       end
     end
   end

--- a/lib/gem_docs/commands/classes.rb
+++ b/lib/gem_docs/commands/classes.rb
@@ -9,7 +9,7 @@ module GemDocs
 
       def call(gem_name:, version: nil, format: "text", **_kwargs)
         loaded_gem = doc_registry.load_gem(gem_name, version: version)
-        out.puts GemDocs::Formatters.for(format).classes(gem: gem_name, entries: class_payloads(loaded_gem))
+        out.puts GemDocs::Formatters.for(format).classes(entries: class_payloads(loaded_gem))
         0
       end
 
@@ -20,6 +20,8 @@ module GemDocs
       end
 
       def class_payloads(loaded_gem)
+        method_counts = method_counts_for(loaded_gem.objects)
+
         loaded_gem.classes
           .select { |entry| visible_named_entry?(entry) }
           .sort_by(&:path)
@@ -29,7 +31,7 @@ module GemDocs
               type: entry.kind.to_s,
               superclass: class_superclass(entry),
               summary: summary_for(entry),
-              method_count: method_count_for(loaded_gem, entry)
+              method_count: method_counts.fetch(entry.path, 0)
             }
           end
       end
@@ -55,13 +57,20 @@ module GemDocs
         entry.docstring.to_s.lines.map(&:strip).reject(&:empty?).first.to_s
       end
 
-      def method_count_for(loaded_gem, entry)
-        loaded_gem.objects.count do |object|
-          next false unless [ :class_method, :instance_method ].include?(object.kind)
-          next false unless object.visibility == :public
+      def method_counts_for(objects)
+        objects.each_with_object(Hash.new(0)) do |object, counts|
+          next unless [ :class_method, :instance_method ].include?(object.kind)
+          next unless object.visibility == :public
 
-          object.path.start_with?("#{entry.path}#", "#{entry.path}.")
+          owner_path = method_owner_path(object.path)
+          next if owner_path.nil? || owner_path.empty?
+
+          counts[owner_path] += 1
         end
+      end
+
+      def method_owner_path(path)
+        path.to_s.split(/[.#]/, 2).first
       end
     end
   end

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -35,12 +35,22 @@ module GemDocs
       end
 
       def classes(gem:, entries:)
-        call(
-          compact_value(
-            gem: gem,
-            classes: entries.map { |entry| compact_value(normalize_entry(entry)) }
-          )
-        )
+        payload = entries.map do |entry|
+          normalized_entry = normalize_entry(entry)
+          name = normalized_entry[:path] || normalized_entry.fetch(:name)
+          type = normalized_entry.key?(:type) ? normalized_entry[:type] : normalized_entry.fetch(:kind).to_s
+          summary = normalized_entry.key?(:summary) ? normalized_entry[:summary] : normalized_entry[:docstring].to_s
+          payload_entry = {
+            name: name,
+            type: type,
+            summary: summary,
+            method_count: normalized_entry.fetch(:method_count, 0)
+          }
+          payload_entry[:superclass] = normalized_entry[:superclass] if normalized_entry[:superclass]
+          payload_entry
+        end
+
+        call(payload)
       end
 
       def lookup(result:)

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -34,7 +34,7 @@ module GemDocs
         call(payload)
       end
 
-      def classes(gem:, entries:)
+      def classes(entries:)
         payload = entries.map do |entry|
           normalized_entry = normalize_entry(entry)
           name = normalized_entry[:path] || normalized_entry.fetch(:name)

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -53,10 +53,40 @@ module GemDocs
       end
 
       def classes(gem:, entries:)
-        build_sections(
-          "#{gem} classes",
-          *entries.map { |entry| "- #{normalize_entry(entry).fetch(:path)}" }
+        normalized_entries = entries.map do |entry|
+          normalized_entry = normalize_entry(entry)
+          name = normalized_entry[:path] || normalized_entry.fetch(:name)
+          type = normalized_entry.key?(:type) ? normalized_entry[:type] : normalized_entry.fetch(:kind).to_s
+          summary = normalized_entry.key?(:summary) ? normalized_entry[:summary] : normalized_entry[:docstring].to_s
+          {
+            name: name,
+            type: type,
+            summary: summary,
+            method_count: normalized_entry.fetch(:method_count, 0)
+          }
+        end
+
+        widths = column_widths(
+          normalized_entries.map do |entry|
+            [
+              entry.fetch(:name),
+              entry.fetch(:type),
+              method_count_label(entry.fetch(:method_count))
+            ]
+          end
         )
+
+        normalized_entries.map do |entry|
+          line = format_row(
+            [
+              entry.fetch(:name),
+              entry.fetch(:type),
+              method_count_label(entry.fetch(:method_count))
+            ],
+            widths
+          )
+          [ line, entry.fetch(:summary) ].reject(&:empty?).join("  ")
+        end.join("\n")
       end
 
       def lookup(result:)
@@ -100,6 +130,11 @@ module GemDocs
         return if source_location.nil? || source_location.empty?
 
         "Source: #{source_location}"
+      end
+
+      def method_count_label(method_count)
+        noun = method_count == 1 ? "method" : "methods"
+        "(#{method_count} #{noun})"
       end
     end
   end

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -52,7 +52,7 @@ module GemDocs
         )
       end
 
-      def classes(gem:, entries:)
+      def classes(entries:)
         normalized_entries = entries.map do |entry|
           normalized_entry = normalize_entry(entry)
           name = normalized_entry[:path] || normalized_entry.fetch(:name)

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -216,7 +216,7 @@ module GemDocs
       def error: (untyped payload) -> String
       def list: (gems: Array[untyped]) -> String
       def summary: (gem: untyped) -> String
-      def classes: (gem: String, entries: Array[untyped]) -> String
+      def classes: (entries: Array[untyped]) -> String
       def lookup: (result: GemDocs::DocRegistry::Entry) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
 
@@ -233,7 +233,7 @@ module GemDocs
       def error: (untyped payload) -> String
       def list: (gems: Array[untyped]) -> String
       def summary: (gem: untyped) -> String
-      def classes: (gem: String, entries: Array[untyped]) -> String
+      def classes: (entries: Array[untyped]) -> String
       def lookup: (result: GemDocs::DocRegistry::Entry) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
     end
@@ -243,7 +243,7 @@ module GemDocs
       def error: (Hash[Symbol, untyped] payload) -> String
       def list: (gems: Array[Hash[Symbol, untyped]]) -> String
       def summary: (gem: untyped) -> String
-      def classes: (gem: String, entries: Array[untyped]) -> String
+      def classes: (entries: Array[untyped]) -> String
       def lookup: (result: GemDocs::DocRegistry::Entry) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
 
@@ -323,7 +323,8 @@ module GemDocs::Commands
     def anonymous_entry?: (GemDocs::DocRegistry::Entry entry) -> bool
     def class_superclass: (GemDocs::DocRegistry::Entry entry) -> String?
     def summary_for: (GemDocs::DocRegistry::Entry entry) -> String
-    def method_count_for: (GemDocs::DocRegistry::LoadedGem loaded_gem, GemDocs::DocRegistry::Entry entry) -> Integer
+    def method_counts_for: (Array[GemDocs::DocRegistry::Entry] objects) -> Hash[String, Integer]
+    def method_owner_path: (String path) -> String
   end
 
   class Context < Base

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -216,7 +216,7 @@ module GemDocs
       def error: (untyped payload) -> String
       def list: (gems: Array[untyped]) -> String
       def summary: (gem: untyped) -> String
-      def classes: (gem: String, entries: Array[GemDocs::DocRegistry::Entry]) -> String
+      def classes: (gem: String, entries: Array[untyped]) -> String
       def lookup: (result: GemDocs::DocRegistry::Entry) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
 
@@ -233,7 +233,7 @@ module GemDocs
       def error: (untyped payload) -> String
       def list: (gems: Array[untyped]) -> String
       def summary: (gem: untyped) -> String
-      def classes: (gem: String, entries: Array[GemDocs::DocRegistry::Entry]) -> String
+      def classes: (gem: String, entries: Array[untyped]) -> String
       def lookup: (result: GemDocs::DocRegistry::Entry) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
     end
@@ -243,7 +243,7 @@ module GemDocs
       def error: (Hash[Symbol, untyped] payload) -> String
       def list: (gems: Array[Hash[Symbol, untyped]]) -> String
       def summary: (gem: untyped) -> String
-      def classes: (gem: String, entries: Array[GemDocs::DocRegistry::Entry]) -> String
+      def classes: (gem: String, entries: Array[untyped]) -> String
       def lookup: (result: GemDocs::DocRegistry::Entry) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
 
@@ -252,6 +252,7 @@ module GemDocs
       def build_sections: (*String? lines) -> String
       def column_widths: (Array[Array[String]] rows) -> Array[Integer]
       def format_row: (Array[String] values, Array[Integer] widths) -> String
+      def method_count_label: (Integer method_count) -> String
       def section: (String title, Array[String]? values) -> String?
       def source_location_line: (String? source_location) -> String?
     end
@@ -312,7 +313,17 @@ module GemDocs::Commands
   end
 
   class Classes < Base
-    def call: (**untyped) -> Integer
+    def call: (gem_name: String, ?version: String?, ?format: String, **untyped) -> Integer
+
+    private
+
+    def doc_registry: -> GemDocs::DocRegistry
+    def class_payloads: (GemDocs::DocRegistry::LoadedGem loaded_gem) -> Array[Hash[Symbol, untyped]]
+    def visible_named_entry?: (GemDocs::DocRegistry::Entry entry) -> bool
+    def anonymous_entry?: (GemDocs::DocRegistry::Entry entry) -> bool
+    def class_superclass: (GemDocs::DocRegistry::Entry entry) -> String?
+    def summary_for: (GemDocs::DocRegistry::Entry entry) -> String
+    def method_count_for: (GemDocs::DocRegistry::LoadedGem loaded_gem, GemDocs::DocRegistry::Entry entry) -> Integer
   end
 
   class Context < Base

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -103,6 +103,26 @@ RSpec.describe GemDocs::CLI do
     )
   end
 
+  it "renders structured JSON errors for classes lookup failures" do
+    stub_const("GemDocs::Commands::Classes", Class.new(GemDocs::Commands::Base) do
+      desc "List documented classes and modules"
+      argument :gem_name, type: :string
+
+      def call(**)
+        raise GemDocs::GemNotFound.new("missing-gem")
+      end
+    end)
+
+    status = described_class.start([ "classes", "missing-gem", "--format", "json" ], out: stdout, err: stderr)
+
+    expect(status).to eq(1)
+    expect(stdout.string).to eq("")
+    expect(JSON.parse(stderr.string)).to eq(
+      "error" => "not_found",
+      "message" => "Gem 'missing-gem' is not installed"
+    )
+  end
+
   it "accepts --version for the summary command" do
     registry = instance_double(
       GemDocs::DocRegistry,

--- a/spec/commands/classes_spec.rb
+++ b/spec/commands/classes_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Commands::Classes do
+  def build_entry(path:, kind: :class, visibility: :public, docstring: "", superclass: nil)
+    GemDocs::DocRegistry::Entry.new(
+      path: path,
+      name: path.split(/[:#.]/).last,
+      kind: kind,
+      visibility: visibility,
+      docstring: docstring,
+      signature: path,
+      source_location: nil,
+      superclass: superclass,
+      doc_source: :yard
+    )
+  end
+
+  def build_loaded_gem(name:, version: "1.0.0", summary: "", objects:)
+    GemDocs::DocRegistry::LoadedGem.new(
+      name: name,
+      version: version,
+      summary: summary,
+      path: "/tmp/#{name}",
+      doc_source: :yard,
+      objects: objects
+    )
+  end
+
+  let(:stdout) { StringIO.new }
+  let(:command) { described_class.new }
+  let(:registry) { instance_double(GemDocs::DocRegistry) }
+
+  before do
+    allow(command).to receive(:out).and_return(stdout)
+    allow(command).to receive(:doc_registry).and_return(registry)
+  end
+
+  it "renders classes as JSON with type, superclass, summary, and method count" do
+    allow(registry).to receive(:load_gem).with("example", version: nil).and_return(
+      build_loaded_gem(
+        name: "example",
+        objects: [
+          build_entry(path: "Example::Widget", docstring: "Widget summary.\n\nMore details.", superclass: "BaseWidget"),
+          build_entry(path: "Example::Widget#call", kind: :instance_method),
+          build_entry(path: "Example::Widget.build", kind: :class_method)
+        ]
+      )
+    )
+
+    status = command.call(gem_name: "example", format: "json")
+
+    expect(status).to eq(0)
+    expect(JSON.parse(stdout.string)).to eq(
+      [
+        {
+          "name" => "Example::Widget",
+          "type" => "class",
+          "superclass" => "BaseWidget",
+          "summary" => "Widget summary.",
+          "method_count" => 2
+        }
+      ]
+    )
+  end
+
+  it "sorts results alphabetically and excludes private or anonymous entries" do
+    allow(registry).to receive(:load_gem).with("example", version: nil).and_return(
+      build_loaded_gem(
+        name: "example",
+        objects: [
+          build_entry(path: "Example::Zulu", docstring: "", superclass: nil),
+          build_entry(path: "Example::Zulu#call", kind: :instance_method),
+          build_entry(path: "Example::Alpha", kind: :module, docstring: "Alpha summary"),
+          build_entry(path: "Example::Alpha.configure", kind: :class_method),
+          build_entry(path: "Example::Hidden", visibility: :private),
+          build_entry(path: "#<Class:0x1234>"),
+          build_entry(path: "#<Class:0x1234>#call", kind: :instance_method)
+        ]
+      )
+    )
+
+    command.call(gem_name: "example", format: "json")
+
+    expect(JSON.parse(stdout.string)).to eq(
+      [
+        {
+          "name" => "Example::Alpha",
+          "type" => "module",
+          "summary" => "Alpha summary",
+          "method_count" => 1
+        },
+        {
+          "name" => "Example::Zulu",
+          "type" => "class",
+          "superclass" => "Object",
+          "summary" => "",
+          "method_count" => 1
+        }
+      ]
+    )
+  end
+
+  it "renders readable text rows for scanning a gem surface area" do
+    allow(registry).to receive(:load_gem).with("example", version: nil).and_return(
+      build_loaded_gem(
+        name: "example",
+        objects: [
+          build_entry(path: "Example::Alpha", kind: :module, docstring: "Alpha summary"),
+          build_entry(path: "Example::Alpha.configure", kind: :class_method),
+          build_entry(path: "Example::Widget", docstring: "Widget summary", superclass: "BaseWidget"),
+          build_entry(path: "Example::Widget#call", kind: :instance_method),
+          build_entry(path: "Example::Widget.build", kind: :class_method)
+        ]
+      )
+    )
+
+    status = command.call(gem_name: "example", format: "text")
+
+    expect(status).to eq(0)
+    expect(stdout.string.lines).to eq(
+      [
+        "Example::Alpha   module  (1 method)   Alpha summary\n",
+        "Example::Widget  class   (2 methods)  Widget summary\n"
+      ]
+    )
+  end
+end

--- a/spec/formatters/json_spec.rb
+++ b/spec/formatters/json_spec.rb
@@ -141,7 +141,6 @@ RSpec.describe GemDocs::Formatters::Json do
       formatter = described_class.new
 
       output = formatter.classes(
-        gem: "rack",
         entries: [
           {
             name: "Rack::Builder",

--- a/spec/formatters/json_spec.rb
+++ b/spec/formatters/json_spec.rb
@@ -137,36 +137,42 @@ RSpec.describe GemDocs::Formatters::Json do
   end
 
   describe "#classes" do
-    it "serializes registry entries without requiring hash access" do
+    it "serializes class listing payloads using the public contract" do
       formatter = described_class.new
 
       output = formatter.classes(
         gem: "rack",
         entries: [
-          build_entry(path: "Rack::Builder"),
-          build_entry(path: "Rack::Request", docstring: "Request wrapper")
+          {
+            name: "Rack::Builder",
+            type: "class",
+            superclass: "Object",
+            summary: "",
+            method_count: 2
+          },
+          {
+            name: "Rack::Request",
+            type: "module",
+            summary: "Request wrapper",
+            method_count: 1
+          }
         ]
       )
 
       expect(JSON.parse(output)).to eq(
-        "gem" => "rack",
-        "classes" => [
+        [
           {
-            "path" => "Rack::Builder",
-            "name" => "Builder",
-            "kind" => "class",
-            "visibility" => "public",
-            "signature" => "Rack::Builder",
-            "doc_source" => "yard"
+            "name" => "Rack::Builder",
+            "type" => "class",
+            "superclass" => "Object",
+            "summary" => "",
+            "method_count" => 2
           },
           {
-            "path" => "Rack::Request",
-            "name" => "Request",
-            "kind" => "class",
-            "visibility" => "public",
-            "docstring" => "Request wrapper",
-            "signature" => "Rack::Request",
-            "doc_source" => "yard"
+            "name" => "Rack::Request",
+            "type" => "module",
+            "summary" => "Request wrapper",
+            "method_count" => 1
           }
         ]
       )

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe GemDocs::Formatters::Text do
       formatter = described_class.new
 
       output = formatter.classes(
-        gem: "rack",
         entries: [
           {
             name: "Rack::Builder",

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -82,18 +82,31 @@ RSpec.describe GemDocs::Formatters::Text do
   end
 
   describe "#classes" do
-    it "renders registry entries without requiring hash access" do
+    it "renders aligned text rows for the class listing contract" do
       formatter = described_class.new
 
       output = formatter.classes(
         gem: "rack",
         entries: [
-          build_entry(path: "Rack::Builder"),
-          build_entry(path: "Rack::Request")
+          {
+            name: "Rack::Builder",
+            type: "class",
+            summary: "",
+            method_count: 12
+          },
+          {
+            name: "Rack::Request",
+            type: "module",
+            summary: "Request wrapper",
+            method_count: 1
+          }
         ]
       )
 
-      expect(output).to eq("rack classes\n- Rack::Builder\n- Rack::Request")
+      expect(output).to eq(
+        "Rack::Builder  class   (12 methods)\n" \
+        "Rack::Request  module  (1 method)    Request wrapper"
+      )
     end
   end
 


### PR DESCRIPTION
## Summary
- implement the classes command for text and JSON output
- filter/sort public class and module entries while reporting summaries, superclasses, and method counts
- add command, formatter, CLI, and type coverage for the new contract

Closes #8

## Test plan
- bundle exec rubocop -a
- bundle exec rspec
- bundle exec steep check