### PR TITLE
feat: implement lookup command

### DIFF
--- a/lib/gem_docs/ambiguous_lookup.rb
+++ b/lib/gem_docs/ambiguous_lookup.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class AmbiguousLookup < Error
+    attr_reader :candidates
+
+    def initialize(path, candidates:)
+      @candidates = candidates
+      super("Multiple matches found for '#{path}'")
+    end
+
+    def error_code
+      "ambiguous"
+    end
+
+    def to_h
+      { error: error_code, message: message, candidates: candidates }
+    end
+  end
+end

--- a/lib/gem_docs/commands/lookup.rb
+++ b/lib/gem_docs/commands/lookup.rb
@@ -4,9 +4,103 @@ module GemDocs
   module Commands
     class Lookup < Base
       desc "Look up a constant or method"
+      argument :path, type: :string
+      option :gem, desc: "Gem name"
 
-      def call(**_kwargs)
-        placeholder("lookup")
+      def call(path:, gem: nil, format: "text", **_kwargs)
+        out.puts GemDocs::Formatters.for(format).lookup(result: lookup_payload(resolve(path, gem_name: gem)))
+        0
+      end
+
+      private
+
+      def doc_registry
+        @doc_registry ||= GemDocs::DocRegistry.new
+      end
+
+      def installed_specs
+        Gem::Specification.to_a.sort_by(&:name)
+      end
+
+      def resolve(path, gem_name:)
+        return resolve_in_gem(path, gem_name) if gem_name
+
+        matches = installed_specs.flat_map do |spec|
+          lookup_matches(path, spec.name)
+        end
+        return matches.first if matches.one?
+        raise GemDocs::AmbiguousLookup.new(path, candidates: candidate_labels(matches)) if matches.any?
+
+        core_entry = doc_registry.find_core_object(path)
+        return { gem_name: "ruby", version: RUBY_VERSION, entry: core_entry } if core_entry
+
+        raise GemDocs::LookupNotFound.new(path)
+      end
+
+      def resolve_in_gem(path, gem_name)
+        matches = lookup_matches(path, gem_name)
+        return matches.first if matches.one?
+        raise GemDocs::AmbiguousLookup.new(path, candidates: candidate_labels(matches)) if matches.any?
+
+        raise GemDocs::LookupNotFound.new(path)
+      end
+
+      def lookup_matches(path, gem_name)
+        loaded_gem = doc_registry.load_gem(gem_name)
+        exact_match = doc_registry.find_object(path, gem_name: gem_name)
+        return [ { gem_name: loaded_gem.name, version: loaded_gem.version, entry: exact_match } ] if exact_match
+
+        fuzzy_matches = loaded_gem.objects.filter_map do |entry|
+          next unless fuzzy_match?(entry.path, path)
+
+          resolved_entry = loaded_gem.find(entry.path) || entry
+          { gem_name: loaded_gem.name, version: loaded_gem.version, entry: resolved_entry }
+        end
+
+        fuzzy_matches.uniq do |match|
+          entry = match.fetch(:entry)
+          entry_path = entry.is_a?(GemDocs::DocRegistry::Entry) ? entry.path : entry.to_s
+          [ match.fetch(:gem_name), entry_path ]
+        end
+      end
+
+      def fuzzy_match?(candidate_path, query)
+        normalized_candidate = candidate_path.downcase
+        normalized_query = query.downcase
+
+        normalized_candidate.end_with?(normalized_query) ||
+          normalized_candidate.end_with?("::#{normalized_query}") ||
+          normalized_candidate.end_with?("##{normalized_query}") ||
+          normalized_candidate.end_with?(".#{normalized_query}") ||
+          normalized_candidate.split(/::|#|\./).last == normalized_query
+      end
+
+      def candidate_labels(matches)
+        duplicate_paths = matches.group_by { |match| match[:entry].path }.select { |_path, grouped| grouped.size > 1 }.keys
+
+        matches.map do |match|
+          label = match[:entry].path
+          duplicate_paths.include?(label) ? "#{match[:gem_name]}:#{label}" : label
+        end
+      end
+
+      def lookup_payload(result)
+        entry = result.fetch(:entry)
+
+        {
+          path: entry.path,
+          name: entry.name,
+          kind: entry.kind,
+          gem: result.fetch(:gem_name),
+          version: result.fetch(:version),
+          doc_source: entry.doc_source,
+          visibility: entry.visibility,
+          signature: entry.signature,
+          docstring: entry.docstring,
+          tags: entry.tags,
+          source_location: entry.source_location,
+          aliases: entry.aliases
+        }
       end
     end
   end

--- a/lib/gem_docs/commands/lookup.rb
+++ b/lib/gem_docs/commands/lookup.rb
@@ -67,9 +67,13 @@ module GemDocs
       def fuzzy_match?(candidate_path, query)
         normalized_candidate = candidate_path.downcase
         normalized_query = query.downcase
+        return true if normalized_candidate == normalized_query
 
-        normalized_candidate.end_with?(normalized_query) ||
-          normalized_candidate.end_with?("::#{normalized_query}") ||
+        suffix_index = normalized_candidate.rindex(normalized_query)
+        prefix = suffix_index ? normalized_candidate[0...suffix_index].to_s : ""
+        return true if !prefix.empty? && prefix.end_with?("::", "#", ".")
+
+        normalized_candidate.end_with?("::#{normalized_query}") ||
           normalized_candidate.end_with?("##{normalized_query}") ||
           normalized_candidate.end_with?(".#{normalized_query}") ||
           normalized_candidate.split(/::|#|\./).last == normalized_query

--- a/lib/gem_docs/commands/lookup.rb
+++ b/lib/gem_docs/commands/lookup.rb
@@ -71,7 +71,9 @@ module GemDocs
 
         suffix_index = normalized_candidate.rindex(normalized_query)
         prefix = suffix_index ? normalized_candidate[0...suffix_index].to_s : ""
-        return true if !prefix.empty? && prefix.end_with?("::", "#", ".")
+        suffix = suffix_index ? normalized_candidate[(suffix_index + normalized_query.length)..].to_s : ""
+        boundary_match = suffix.empty? || suffix.start_with?("::", "#", ".")
+        return true if !prefix.empty? && prefix.end_with?("::", "#", ".") && boundary_match
 
         normalized_candidate.end_with?("::#{normalized_query}") ||
           normalized_candidate.end_with?("##{normalized_query}") ||

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -18,7 +18,9 @@ module GemDocs
       :signature,
       :source_location,
       :superclass,
-      :doc_source
+      :doc_source,
+      :tags,
+      :aliases
     )
       def class_or_module?
         kind == :class || kind == :module
@@ -168,6 +170,26 @@ module GemDocs
 
     def classes_for(gem_name)
       load_gem(gem_name).classes.sort_by(&:path)
+    end
+
+    def find_core_object(path)
+      response = run_shell(*ri_core_command(path))
+      return unless response[:success]
+
+      signature, docstring = parse_rdoc_output(response[:stdout])
+      Entry.new(
+        path: path,
+        name: path.split(/[#.]/).last,
+        kind: rdoc_kind_for(path, signature),
+        visibility: :public,
+        docstring: docstring,
+        signature: signature.empty? ? path : signature,
+        source_location: nil,
+        superclass: nil,
+        doc_source: :rdoc,
+        tags: {},
+        aliases: []
+      )
     end
 
     private
@@ -360,7 +382,9 @@ module GemDocs
         signature: name,
         source_location: nil,
         superclass: nil,
-        doc_source: :rdoc
+        doc_source: :rdoc,
+        tags: {},
+        aliases: []
       )
     end
 
@@ -378,7 +402,9 @@ module GemDocs
         signature: signature.empty? ? path : signature,
         source_location: nil,
         superclass: nil,
-        doc_source: :rdoc
+        doc_source: :rdoc,
+        tags: {},
+        aliases: []
       )
     end
 
@@ -392,7 +418,9 @@ module GemDocs
         signature: object.path,
         source_location: yard_source_location(object),
         superclass: yard_superclass(object),
-        doc_source: :yard
+        doc_source: :yard,
+        tags: yard_tags(object),
+        aliases: yard_aliases(object)
       )
     end
 
@@ -406,7 +434,9 @@ module GemDocs
         signature: object.signature || object.path,
         source_location: yard_source_location(object),
         superclass: nil,
-        doc_source: :yard
+        doc_source: :yard,
+        tags: yard_tags(object),
+        aliases: yard_aliases(object)
       )
     end
 
@@ -420,7 +450,9 @@ module GemDocs
         signature: object.path,
         source_location: yard_source_location(object),
         superclass: nil,
-        doc_source: :yard
+        doc_source: :yard,
+        tags: yard_tags(object),
+        aliases: yard_aliases(object)
       )
     end
 
@@ -517,7 +549,9 @@ module GemDocs
             signature: build_method_signature(namespace_path, node, class_method: class_method),
             source_location: format_source_location(file, node.location.start_line),
             superclass: nil,
-            doc_source: :source_only
+            doc_source: :source_only,
+            tags: {},
+            aliases: []
           )
         when Prism::ConstantWriteNode
           constant_path = join_constant_path(namespace_path, node.name.to_s)
@@ -530,7 +564,9 @@ module GemDocs
             signature: constant_path,
             source_location: format_source_location(file, node.location.start_line),
             superclass: nil,
-            doc_source: :source_only
+            doc_source: :source_only,
+            tags: {},
+            aliases: []
           )
         else
           push_children(stack, node, namespace_path, class_method_context)
@@ -550,7 +586,9 @@ module GemDocs
         signature: path,
         source_location: format_source_location(file, line),
         superclass: superclass,
-        doc_source: :source_only
+        doc_source: :source_only,
+        tags: {},
+        aliases: []
       )
     end
 
@@ -617,6 +655,36 @@ module GemDocs
       superclass.respond_to?(:path) ? superclass.path : superclass.to_s
     end
 
+    def yard_tags(object)
+      return {} unless object.respond_to?(:tags)
+
+      object.tags.each_with_object({}) do |tag, grouped_tags|
+        normalized = normalize_yard_tag(tag)
+        next if normalized.nil?
+
+        grouped_tags[tag.tag_name.to_sym] ||= []
+        grouped_tags[tag.tag_name.to_sym] << normalized
+      end
+    end
+
+    def normalize_yard_tag(tag)
+      return tag.text.to_s.strip if tag.tag_name == "example"
+
+      payload = {}
+      payload[:name] = tag.name if tag.respond_to?(:name) && tag.name
+      payload[:types] = Array(tag.types).map(&:to_s) if tag.respond_to?(:types)
+      payload[:text] = tag.text.to_s.strip
+      payload
+    end
+
+    def yard_aliases(object)
+      return [] unless object.respond_to?(:aliases)
+
+      Array(object.aliases).filter_map do |alias_object|
+        alias_object.respond_to?(:path) ? alias_object.path : alias_object.to_s
+      end
+    end
+
     def parse_rdoc_output(output)
       lines = output.lines.map(&:rstrip)
       signature = lines.first.to_s.strip
@@ -645,6 +713,10 @@ module GemDocs
 
     def ri_command(spec, *arguments)
       [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "--", *arguments ]
+    end
+
+    def ri_core_command(*arguments)
+      [ "ri", "--no-pager", "--", *arguments ]
     end
 
     def run_shell(*command)

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -54,7 +54,14 @@ module GemDocs
       end
 
       def lookup(result:)
-        call(compact_value(normalize_entry(result)))
+        normalized_result = normalize_entry(result)
+        payload = compact_value(normalized_result) || {}
+        payload[:docstring] = normalized_result.fetch(:docstring, "").to_s
+        tags = normalized_result[:tags]
+        payload[:tags] = tags.nil? ? Hash.new : (compact_value(tags) || Hash.new)
+        aliases = normalized_result[:aliases]
+        payload[:aliases] = aliases.is_a?(Array) ? aliases.map { |value| value.to_s } : Array.new
+        call(payload)
       end
 
       def search(results:)

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -91,12 +91,19 @@ module GemDocs
 
       def lookup(result:)
         normalized_result = normalize_entry(result)
+        metadata = [
+          [ normalized_result[:gem], normalized_result[:version] ].compact.join(" "),
+          normalized_result[:doc_source]
+        ].reject { |value| value.nil? || value.to_s.empty? }.join(" · ")
 
         build_sections(
-          normalized_result.fetch(:path),
+          metadata.empty? ? normalized_result.fetch(:path) : "#{normalized_result.fetch(:path)}  [#{metadata}]",
+          normalized_result[:source_location],
+          nil,
           normalized_result[:signature],
           normalized_result[:docstring],
-          source_location_line(normalized_result[:source_location])
+          tag_sections(normalized_result[:tags]),
+          aliases_section(normalized_result[:aliases])
         )
       end
 
@@ -130,6 +137,66 @@ module GemDocs
         return if source_location.nil? || source_location.empty?
 
         "Source: #{source_location}"
+      end
+
+      def tag_sections(tags)
+        return "" unless tags.is_a?(Hash)
+
+        tags.flat_map do |tag_name, values|
+          case tag_name.to_s
+          when "param"
+            build_param_lines(values)
+          when "return"
+            build_type_lines("Returns", values)
+          when "raise"
+            build_type_lines("Raises", values)
+          when "example"
+            build_example_lines(values)
+          else
+            next
+          end
+        end.compact.join("\n")
+      end
+
+      def build_param_lines(values)
+        return unless values.is_a?(Array) && !values.empty?
+
+        [
+          "Params:",
+          *values.map do |value|
+            next value.to_s unless value.is_a?(Hash)
+
+            types = Array(value[:types]).join(" | ")
+            [ "  #{value[:name]}", types, value[:text] ].reject(&:empty?).join("  ")
+          end
+        ].compact
+      end
+
+      def build_type_lines(title, values)
+        return unless values.is_a?(Array)
+
+        value = values.first
+        return unless value.is_a?(Hash)
+
+        raw_types = value.fetch(:types, nil)
+        types = raw_types.is_a?(Array) ? raw_types.map { |type| type.to_s }.join(" | ") : ""
+        [ title + ":", types, value.fetch(:text, "").to_s ].reject(&:empty?).join("  ")
+      end
+
+      def build_example_lines(values)
+        return unless values.is_a?(Array) && !values.empty?
+
+        [
+          "Example:",
+          *values.map { |value| "  #{value}" }
+        ]
+      end
+
+      def aliases_section(aliases)
+        aliases = Array(aliases)
+        return if aliases.empty?
+
+        "Aliases: #{aliases.join(', ')}"
       end
 
       def method_count_label(method_count)

--- a/lib/gem_docs/lookup_not_found.rb
+++ b/lib/gem_docs/lookup_not_found.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class LookupNotFound < Error
+    def initialize(path, message: nil)
+      super(message || "No method matching '#{path}'")
+    end
+
+    def error_code
+      "not_found"
+    end
+  end
+end

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -75,6 +75,19 @@ module GemDocs
     def error_code: -> String
   end
 
+  class LookupNotFound < Error
+    def initialize: (String path, ?message: String?) -> void
+    def error_code: -> String
+  end
+
+  class AmbiguousLookup < Error
+    attr_reader candidates: Array[String]
+
+    def initialize: (String path, candidates: Array[String]) -> void
+    def error_code: -> String
+    def to_h: -> Hash[Symbol, untyped]
+  end
+
   class ConfigurationError < Error
     def error_code: -> String
   end
@@ -90,6 +103,8 @@ module GemDocs
       attr_reader source_location: String?
       attr_reader superclass: String?
       attr_reader doc_source: doc_source
+      attr_reader tags: Hash[Symbol, untyped]
+      attr_reader aliases: Array[String]
 
       def initialize: (
         path: String,
@@ -100,7 +115,9 @@ module GemDocs
         signature: String,
         source_location: String?,
         superclass: String?,
-        doc_source: doc_source
+        doc_source: doc_source,
+        tags: Hash[Symbol, untyped],
+        aliases: Array[String]
       ) -> void
       def class_or_module?: -> bool
       def to_h: -> Hash[Symbol, untyped]
@@ -148,6 +165,7 @@ module GemDocs
     def doc_source_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> doc_source
     def find_object: (String path, gem_name: String) -> Entry?
     def classes_for: (String gem_name) -> Array[Entry]
+    def find_core_object: (String path) -> Entry?
 
     private
 
@@ -182,10 +200,14 @@ module GemDocs
     def format_source_location: (String file, Integer line) -> String
     def yard_source_location: (YARD::CodeObjects::BaseObject object) -> String?
     def yard_superclass: (YARD::CodeObjects::NamespaceObject object) -> String?
+    def yard_tags: (untyped object) -> Hash[Symbol, untyped]
+    def normalize_yard_tag: (untyped tag) -> (Hash[Symbol, untyped] | String)?
+    def yard_aliases: (untyped object) -> Array[String]
     def parse_rdoc_output: (String output) -> [String, String]
     def rdoc_kind_for: (String path, String signature) -> entry_kind
     def ri_list_command: (Gem::Specification spec) -> Array[String]
     def ri_command: (Gem::Specification spec, *String arguments) -> Array[String]
+    def ri_core_command: (*String arguments) -> Array[String]
     def run_shell: (*String command) -> command_response
     def run_command: (Array[String] command) -> command_response
     def command_execution_failed?: (command_response response) -> bool
@@ -217,7 +239,7 @@ module GemDocs
       def list: (gems: Array[untyped]) -> String
       def summary: (gem: untyped) -> String
       def classes: (entries: Array[untyped]) -> String
-      def lookup: (result: GemDocs::DocRegistry::Entry) -> String
+      def lookup: (result: untyped) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
 
       private
@@ -234,7 +256,7 @@ module GemDocs
       def list: (gems: Array[untyped]) -> String
       def summary: (gem: untyped) -> String
       def classes: (entries: Array[untyped]) -> String
-      def lookup: (result: GemDocs::DocRegistry::Entry) -> String
+      def lookup: (result: untyped) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
     end
 
@@ -244,7 +266,7 @@ module GemDocs
       def list: (gems: Array[Hash[Symbol, untyped]]) -> String
       def summary: (gem: untyped) -> String
       def classes: (entries: Array[untyped]) -> String
-      def lookup: (result: GemDocs::DocRegistry::Entry) -> String
+      def lookup: (result: untyped) -> String
       def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
 
       private
@@ -255,6 +277,11 @@ module GemDocs
       def method_count_label: (Integer method_count) -> String
       def section: (String title, Array[String]? values) -> String?
       def source_location_line: (String? source_location) -> String?
+      def tag_sections: (untyped tags) -> String
+      def build_param_lines: (untyped values) -> Array[String]?
+      def build_type_lines: (String title, untyped values) -> String?
+      def build_example_lines: (untyped values) -> Array[String]?
+      def aliases_section: (untyped aliases) -> String?
     end
 
     module Context
@@ -342,7 +369,18 @@ module GemDocs::Commands
   end
 
   class Lookup < Base
-    def call: (**untyped) -> Integer
+    def call: (path: String, ?gem: String?, ?format: String, **untyped) -> Integer
+
+    private
+
+    def doc_registry: -> GemDocs::DocRegistry
+    def installed_specs: -> Array[Gem::Specification]
+    def resolve: (String path, gem_name: String?) -> Hash[Symbol, untyped]
+    def resolve_in_gem: (String path, String gem_name) -> Hash[Symbol, untyped]
+    def lookup_matches: (String path, String gem_name) -> Array[Hash[Symbol, untyped]]
+    def fuzzy_match?: (String candidate_path, String query) -> bool
+    def candidate_labels: (Array[Hash[Symbol, untyped]] matches) -> Array[String]
+    def lookup_payload: (Hash[Symbol, untyped] result) -> Hash[Symbol, untyped]
   end
 
   class Search < Base

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,11 +1,53 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "json"
 require "stringio"
+require "tmpdir"
+require "yard"
 require "spec_helper"
 require "gem_docs"
 
 RSpec.describe GemDocs::CLI do
+  def build_fixture_spec(name:, gem_root:, version: "0.1.0", summary: "Fixture gem")
+    Gem::Specification.new do |spec|
+      spec.name = name
+      spec.version = version
+      spec.summary = summary
+      spec.files = Dir.chdir(gem_root) { Dir["lib/**/*.rb"] }
+      spec.require_paths = [ "lib" ]
+    end.tap do |spec|
+      spec.define_singleton_method(:full_gem_path) { gem_root }
+      spec.define_singleton_method(:doc_dir) { File.join(gem_root, "doc") }
+    end
+  end
+
+  def with_yard_fixture_gem(name:, version: "0.1.0", source:)
+    Dir.mktmpdir do |tmpdir|
+      gem_root = File.join(tmpdir, name)
+      file = File.join(gem_root, "lib", "#{name}.rb")
+      yardoc = File.join(gem_root, ".yardoc")
+      FileUtils.mkdir_p(File.dirname(file))
+      File.write(file, source)
+
+      previous_yardoc = YARD::Registry.yardoc_file
+      YARD::Registry.clear
+      YARD.parse(file)
+      YARD::Registry.save(false, yardoc)
+      YARD::Registry.clear
+      YARD::Registry.yardoc_file = previous_yardoc
+
+      spec = build_fixture_spec(name: name, gem_root: gem_root, version: version)
+      allow(GemDocs::DocRegistry).to receive(:gem_spec_for).with(name).and_return(spec)
+      allow(GemDocs::DocRegistry).to receive(:gem_spec_for).with(name, version: version).and_return(spec)
+
+      yield spec
+    ensure
+      YARD::Registry.clear
+      YARD::Registry.yardoc_file = previous_yardoc
+    end
+  end
+
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
 
@@ -143,5 +185,54 @@ RSpec.describe GemDocs::CLI do
     expect(status).to eq(0)
     expect(stderr.string).to eq("")
     expect(registry).to have_received(:load_gem).with("faraday", version: "2.12.0")
+  end
+
+  it "renders structured JSON errors for ambiguous lookups" do
+    with_yard_fixture_gem(name: "alpha", source: <<~RUBY) do |alpha_spec|
+      module Alpha
+        class Widget
+          def call
+          end
+        end
+      end
+    RUBY
+      with_yard_fixture_gem(name: "beta", source: <<~RUBY) do |beta_spec|
+        module Beta
+          class Widget
+            def call
+            end
+          end
+        end
+      RUBY
+        allow(Gem::Specification).to receive(:to_a).and_return([ alpha_spec, beta_spec ])
+
+        status = described_class.start([ "lookup", "Widget#call", "--format", "json" ], out: stdout, err: stderr)
+
+        expect(status).to eq(1)
+        expect(stdout.string).to eq("")
+        expect(JSON.parse(stderr.string)).to eq(
+          "error" => "ambiguous",
+          "message" => "Multiple matches found for 'Widget#call'",
+          "candidates" => [ "Alpha::Widget#call", "Beta::Widget#call" ]
+        )
+      end
+    end
+  end
+
+  it "renders structured JSON errors for missing lookup results" do
+    with_yard_fixture_gem(name: "lookup_fixture", source: "module LookupFixture; end\n") do
+      status = described_class.start(
+        [ "lookup", "LookupFixture#missing", "--gem", "lookup_fixture", "--format", "json" ],
+        out: stdout,
+        err: stderr
+      )
+
+      expect(status).to eq(1)
+      expect(stdout.string).to eq("")
+      expect(JSON.parse(stderr.string)).to eq(
+        "error" => "not_found",
+        "message" => "No method matching 'LookupFixture#missing'"
+      )
+    end
   end
 end

--- a/spec/commands/classes_spec.rb
+++ b/spec/commands/classes_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe GemDocs::Commands::Classes do
       signature: path,
       source_location: nil,
       superclass: superclass,
-      doc_source: :yard
+      doc_source: :yard,
+      tags: {},
+      aliases: []
     )
   end
 

--- a/spec/commands/lookup_spec.rb
+++ b/spec/commands/lookup_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "stringio"
+require "tmpdir"
+require "yard"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Commands::Lookup do
+  def build_fixture_spec(name:, gem_root:, version: "0.1.0", summary: "Fixture gem")
+    Gem::Specification.new do |spec|
+      spec.name = name
+      spec.version = version
+      spec.summary = summary
+      spec.files = Dir.chdir(gem_root) { Dir["lib/**/*.rb"] }
+      spec.require_paths = [ "lib" ]
+    end.tap do |spec|
+      spec.define_singleton_method(:full_gem_path) { gem_root }
+      spec.define_singleton_method(:doc_dir) { File.join(gem_root, "doc") }
+    end
+  end
+
+  def with_yard_fixture_gem(name:, version: "0.1.0", source:)
+    Dir.mktmpdir do |tmpdir|
+      gem_root = File.join(tmpdir, name)
+      file = File.join(gem_root, "lib", "#{name}.rb")
+      yardoc = File.join(gem_root, ".yardoc")
+      FileUtils.mkdir_p(File.dirname(file))
+      File.write(file, source)
+
+      previous_yardoc = YARD::Registry.yardoc_file
+      YARD::Registry.clear
+      YARD.parse(file)
+      YARD::Registry.save(false, yardoc)
+      YARD::Registry.clear
+      YARD::Registry.yardoc_file = previous_yardoc
+
+      spec = build_fixture_spec(name: name, gem_root: gem_root, version: version)
+      allow(GemDocs::DocRegistry).to receive(:gem_spec_for).with(name).and_return(spec)
+      allow(GemDocs::DocRegistry).to receive(:gem_spec_for).with(name, version: version).and_return(spec)
+
+      yield spec
+    ensure
+      YARD::Registry.clear
+      YARD::Registry.yardoc_file = previous_yardoc
+    end
+  end
+
+  def with_source_fixture_gem(name:, version: "0.1.0", source:)
+    Dir.mktmpdir do |tmpdir|
+      gem_root = File.join(tmpdir, name)
+      file = File.join(gem_root, "lib", "#{name}.rb")
+      FileUtils.mkdir_p(File.dirname(file))
+      File.write(file, source)
+
+      spec = build_fixture_spec(name: name, gem_root: gem_root, version: version)
+      allow(GemDocs::DocRegistry).to receive(:gem_spec_for).with(name).and_return(spec)
+      allow(GemDocs::DocRegistry).to receive(:gem_spec_for).with(name, version: version).and_return(spec)
+
+      yield spec
+    end
+  end
+
+  let(:stdout) { StringIO.new }
+  let(:command) { described_class.new }
+
+  before do
+    allow(command).to receive(:out).and_return(stdout)
+  end
+
+  it "renders a JSON lookup payload for a documented instance method" do
+    with_yard_fixture_gem(name: "lookup_fixture", source: <<~RUBY) do
+      module LookupFixture
+        class Client
+          # Performs the request.
+          #
+          # @param input [String] The lookup input.
+          # @return [String]
+          # @example
+          #   LookupFixture::Client.new.call("demo")
+          def call(input)
+          end
+        end
+      end
+    RUBY
+      status = command.call(
+        path: "LookupFixture::Client#call",
+        gem: "lookup_fixture",
+        format: "json"
+      )
+
+      expect(status).to eq(0)
+      payload = JSON.parse(stdout.string)
+
+      expect(payload).to include(
+        "path" => "LookupFixture::Client#call",
+        "name" => "call",
+        "kind" => "instance_method",
+        "gem" => "lookup_fixture",
+        "version" => "0.1.0",
+        "doc_source" => "yard",
+        "signature" => "def call(input)",
+        "visibility" => "public",
+        "docstring" => "Performs the request.",
+        "tags" => {
+          "param" => [
+            {
+              "name" => "input",
+              "types" => [ "String" ],
+              "text" => "The lookup input."
+            }
+          ],
+          "return" => [
+            {
+              "types" => [ "String" ]
+            }
+          ],
+          "example" => [ "LookupFixture::Client.new.call(\"demo\")" ]
+        },
+        "aliases" => []
+      )
+      expect(payload.fetch("source_location")).to match(%r{/lookup_fixture/lib/lookup_fixture\.rb:\d+\z})
+    end
+  end
+
+  it "renders readable text output with signature, params, and examples" do
+    with_yard_fixture_gem(name: "lookup_fixture", source: <<~RUBY) do
+      module LookupFixture
+        class Client
+          # Performs the request.
+          #
+          # @param input [String] The lookup input.
+          # @return [String] The processed response.
+          # @example
+          #   LookupFixture::Client.new.call("demo")
+          def call(input)
+          end
+        end
+      end
+    RUBY
+      status = command.call(
+        path: "LookupFixture::Client#call",
+        gem: "lookup_fixture",
+        format: "text"
+      )
+
+      expect(status).to eq(0)
+      expect(stdout.string).to include("LookupFixture::Client#call  [lookup_fixture 0.1.0 · yard]")
+      expect(stdout.string).to include("def call(input)")
+      expect(stdout.string).to include("Params:")
+      expect(stdout.string).to include("input  String  The lookup input.")
+      expect(stdout.string).to include("Returns:  String  The processed response.")
+      expect(stdout.string).to include("Example:")
+      expect(stdout.string).to include("LookupFixture::Client.new.call(\"demo\")")
+    end
+  end
+
+  it "scopes fuzzy lookup resolution to the requested gem" do
+    with_yard_fixture_gem(name: "alpha", source: <<~RUBY) do |alpha_spec|
+      module Alpha
+        class Widget
+          # Alpha implementation.
+          def call
+          end
+        end
+      end
+    RUBY
+      with_yard_fixture_gem(name: "beta", source: <<~RUBY) do |beta_spec|
+        module Beta
+          class Widget
+            # Beta implementation.
+            def call
+            end
+          end
+        end
+      RUBY
+        allow(Gem::Specification).to receive(:to_a).and_return([ alpha_spec, beta_spec ])
+
+        status = command.call(path: "Widget#call", gem: "beta", format: "json")
+
+        expect(status).to eq(0)
+        expect(JSON.parse(stdout.string)).to include(
+          "path" => "Beta::Widget#call",
+          "gem" => "beta",
+          "docstring" => "Beta implementation."
+        )
+      end
+    end
+  end
+
+  it "preserves empty source-only docstrings in JSON output" do
+    with_source_fixture_gem(name: "source_only", source: <<~RUBY) do
+      module SourceOnly
+        class Widget
+          def call(input)
+          end
+        end
+      end
+    RUBY
+      status = command.call(path: "SourceOnly::Widget#call", gem: "source_only", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to include(
+        "path" => "SourceOnly::Widget#call",
+        "gem" => "source_only",
+        "doc_source" => "source_only",
+        "signature" => "SourceOnly::Widget#call(input)",
+        "docstring" => "",
+        "aliases" => []
+      )
+    end
+  end
+
+  it "falls back to Ruby core ri lookups when no gem match exists" do
+    registry = GemDocs::DocRegistry.new(
+      shell_runner: lambda do |lookup_command|
+        if lookup_command == [ "ri", "--no-pager", "--", "String#gsub" ]
+          {
+            stdout: "String#gsub(pattern, replacement)\n\nSubstitutes occurrences.\n",
+            stderr: "",
+            success: true
+          }
+        else
+          { stdout: "", stderr: "missing", success: false }
+        end
+      end
+    )
+    allow(command).to receive(:doc_registry).and_return(registry)
+    allow(Gem::Specification).to receive(:to_a).and_return([])
+
+    status = command.call(path: "String#gsub", format: "json")
+
+    expect(status).to eq(0)
+    expect(JSON.parse(stdout.string)).to include(
+      "path" => "String#gsub",
+      "gem" => "ruby",
+      "version" => RUBY_VERSION,
+      "doc_source" => "rdoc",
+      "signature" => "String#gsub(pattern, replacement)",
+      "docstring" => "Substitutes occurrences."
+    )
+  end
+end

--- a/spec/commands/lookup_spec.rb
+++ b/spec/commands/lookup_spec.rb
@@ -190,6 +190,26 @@ RSpec.describe GemDocs::Commands::Lookup do
     end
   end
 
+  it "does not treat suffix-only class name matches as ambiguous" do
+    with_yard_fixture_gem(name: "alpha", source: <<~RUBY) do
+      module Alpha
+        class Record
+        end
+
+        class ActiveRecord
+        end
+      end
+    RUBY
+      status = command.call(path: "Record", gem: "alpha", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to include(
+        "path" => "Alpha::Record",
+        "gem" => "alpha"
+      )
+    end
+  end
+
   it "preserves empty source-only docstrings in JSON output" do
     with_source_fixture_gem(name: "source_only", source: <<~RUBY) do
       module SourceOnly

--- a/spec/commands/lookup_spec.rb
+++ b/spec/commands/lookup_spec.rb
@@ -210,6 +210,26 @@ RSpec.describe GemDocs::Commands::Lookup do
     end
   end
 
+  it "does not match partial class name substrings within a segment" do
+    with_yard_fixture_gem(name: "alpha", source: <<~RUBY) do
+      module Alpha
+        class Record
+        end
+
+        class RecordCallable
+        end
+      end
+    RUBY
+      status = command.call(path: "Record", gem: "alpha", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to include(
+        "path" => "Alpha::Record",
+        "gem" => "alpha"
+      )
+    end
+  end
+
   it "preserves empty source-only docstrings in JSON output" do
     with_source_fixture_gem(name: "source_only", source: <<~RUBY) do
       module SourceOnly

--- a/spec/commands/summary_spec.rb
+++ b/spec/commands/summary_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe GemDocs::Commands::Summary do
       signature: path,
       source_location: nil,
       superclass: nil,
-      doc_source: :yard
+      doc_source: :yard,
+      tags: {},
+      aliases: []
     )
   end
 

--- a/spec/formatters/json_spec.rb
+++ b/spec/formatters/json_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 require "gem_docs"
 
 RSpec.describe GemDocs::Formatters::Json do
-  def build_entry(path:, signature: path, docstring: "", source_location: nil, kind: :class)
+  def build_entry(path:, signature: path, docstring: "", source_location: nil, kind: :class, tags: {}, aliases: [])
     GemDocs::DocRegistry::Entry.new(
       path: path,
       name: path.split(/[:#.]/).last,
@@ -15,7 +15,9 @@ RSpec.describe GemDocs::Formatters::Json do
       signature: signature,
       source_location: source_location,
       superclass: nil,
-      doc_source: :yard
+      doc_source: :yard,
+      tags: tags,
+      aliases: aliases
     )
   end
 
@@ -179,25 +181,37 @@ RSpec.describe GemDocs::Formatters::Json do
   end
 
   describe "#lookup" do
-    it "serializes registry entries without requiring hash access" do
+    it "serializes lookup payloads while preserving empty docstrings and aliases" do
       formatter = described_class.new
 
       output = formatter.lookup(
-        result: build_entry(
+        result: {
           path: "Rack::Builder",
-          signature: "Rack::Builder",
-          docstring: "Builds Rack applications"
-        )
+          gem: "rack",
+          version: "3.1.0",
+          doc_source: :yard,
+          signature: "def build(app = nil)",
+          visibility: :public,
+          docstring: "",
+          tags: {
+            example: [ "Rack::Builder.new" ]
+          },
+          aliases: []
+        }
       )
 
       expect(JSON.parse(output)).to eq(
         "path" => "Rack::Builder",
-        "name" => "Builder",
-        "kind" => "class",
+        "gem" => "rack",
+        "version" => "3.1.0",
+        "doc_source" => "yard",
+        "signature" => "def build(app = nil)",
         "visibility" => "public",
-        "docstring" => "Builds Rack applications",
-        "signature" => "Rack::Builder",
-        "doc_source" => "yard"
+        "docstring" => "",
+        "tags" => {
+          "example" => [ "Rack::Builder.new" ]
+        },
+        "aliases" => []
       )
     end
   end

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require "gem_docs"
 
 RSpec.describe GemDocs::Formatters::Text do
-  def build_entry(path:, signature: path, docstring: "", source_location: nil, kind: :class)
+  def build_entry(path:, signature: path, docstring: "", source_location: nil, kind: :class, tags: {}, aliases: [])
     GemDocs::DocRegistry::Entry.new(
       path: path,
       name: path.split(/[:#.]/).last,
@@ -14,7 +14,9 @@ RSpec.describe GemDocs::Formatters::Text do
       signature: signature,
       source_location: source_location,
       superclass: nil,
-      doc_source: :yard
+      doc_source: :yard,
+      tags: tags,
+      aliases: aliases
     )
   end
 
@@ -110,18 +112,37 @@ RSpec.describe GemDocs::Formatters::Text do
   end
 
   describe "#lookup" do
-    it "omits the source line when the entry has no source location" do
+    it "renders lookup metadata, tags, and aliases" do
       formatter = described_class.new
 
       output = formatter.lookup(
-        result: build_entry(
+        result: {
           path: "Rack::Builder",
-          signature: "Rack::Builder",
-          docstring: "Builds Rack applications"
-        )
+          gem: "rack",
+          version: "3.1.0",
+          doc_source: :yard,
+          signature: "def build(app = nil)",
+          docstring: "Builds Rack applications",
+          tags: {
+            param: [
+              { name: "app", types: [ "Rack::App" ], text: "Rack app" }
+            ],
+            example: [ "Rack::Builder.new" ]
+          },
+          aliases: [ "Rack::Builder.compile" ]
+        }
       )
 
-      expect(output).to eq("Rack::Builder\nRack::Builder\nBuilds Rack applications")
+      expect(output).to eq(
+        "Rack::Builder  [rack 3.1.0 · yard]\n" \
+        "def build(app = nil)\n" \
+        "Builds Rack applications\n" \
+        "Params:\n" \
+        "  app  Rack::App  Rack app\n" \
+        "Example:\n" \
+        "  Rack::Builder.new\n" \
+        "Aliases: Rack::Builder.compile"
+      )
     end
   end
 


### PR DESCRIPTION
- add gem-docs lookup with gem scoping, ambiguity handling, Ruby core fallback, and richer text/json output
- extend the registry to surface tags, aliases, and Ruby core ri lookups
- add command, CLI, formatter, and typing coverage for lookup flows

Closes #9

Test plan:
- bundle exec rspec
- bundle exec rubocop -a
- bundle exec steep check