### PR TITLE
feat: add gem-docs search command

### DIFF
--- a/lib/gem_docs/commands/search.rb
+++ b/lib/gem_docs/commands/search.rb
@@ -3,6 +3,8 @@
 module GemDocs
   module Commands
     class Search < Base
+      PER_GEM_LIMIT = 5
+
       desc "Search gem documentation"
       argument :query, type: :string
       option :gem, desc: "Gem name"
@@ -51,8 +53,8 @@ module GemDocs
         loaded_gem = doc_registry.load_gem(gem_name)
         return [] if loaded_gem.doc_source == :none
 
-        ranked_results_for(loaded_gem, query, scope: scope).first(5)
-      rescue GemDocs::Error
+        ranked_results_for(loaded_gem, query, scope: scope).first(PER_GEM_LIMIT)
+      rescue GemDocs::RegistryError, GemDocs::DocUnavailable
         []
       end
 

--- a/lib/gem_docs/commands/search.rb
+++ b/lib/gem_docs/commands/search.rb
@@ -4,9 +4,141 @@ module GemDocs
   module Commands
     class Search < Base
       desc "Search gem documentation"
+      argument :query, type: :string
+      option :gem, desc: "Gem name"
+      option :scope, values: %w[methods classes all], default: "all", desc: "Search scope"
+      option :limit, default: "10", desc: "Maximum results"
 
-      def call(**_kwargs)
-        placeholder("search")
+      def call(query:, gem: nil, scope: "all", limit: "10", format: "text", **_kwargs)
+        results = if gem
+          search_gem(query, gem, scope: scope, limit: normalize_limit(limit))
+        else
+          search_all_gems(query, scope: scope, limit: normalize_limit(limit))
+        end
+
+        out.puts GemDocs::Formatters.for(format).search(results: results)
+        0
+      end
+
+      private
+
+      def doc_registry
+        @doc_registry ||= GemDocs::DocRegistry.new
+      end
+
+      def installed_specs
+        Gem::Specification.to_a.sort_by(&:name)
+      end
+
+      def search_gem(query, gem_name, scope:, limit:)
+        loaded_gem = doc_registry.load_gem(gem_name)
+        return [] if loaded_gem.doc_source == :none
+
+        ranked_results_for(loaded_gem, query, scope: scope).first(limit)
+      end
+
+      def search_all_gems(query, scope:, limit:)
+        installed_specs
+          .reject { |spec| config.exclude_gems.include?(spec.name) }
+          .flat_map do |spec|
+            safe_ranked_results_for(spec.name, query, scope: scope)
+          end
+          .sort_by { |result| [ -result.fetch(:score), result.fetch(:path), result.fetch(:gem) ] }
+          .first(limit)
+      end
+
+      def safe_ranked_results_for(gem_name, query, scope:)
+        loaded_gem = doc_registry.load_gem(gem_name)
+        return [] if loaded_gem.doc_source == :none
+
+        ranked_results_for(loaded_gem, query, scope: scope).first(5)
+      rescue GemDocs::Error
+        []
+      end
+
+      def ranked_results_for(loaded_gem, query, scope:)
+        loaded_gem.objects
+          .filter_map do |entry|
+            next unless searchable_entry?(entry, scope)
+
+            resolved_entry = loaded_gem.find(entry.path) || entry
+            score = score_for(resolved_entry, query)
+            next unless score
+
+            search_payload(resolved_entry, gem_name: loaded_gem.name, score: score)
+          end
+          .uniq { |result| [ result.fetch(:gem), result.fetch(:path) ] }
+          .sort_by { |result| [ -result.fetch(:score), result.fetch(:path), result.fetch(:gem) ] }
+      end
+
+      def searchable_entry?(entry, scope)
+        return false unless entry.visibility == :public
+        return false if anonymous_entry?(entry)
+
+        case scope
+        when "methods"
+          method_entry?(entry)
+        when "classes"
+          class_entry?(entry)
+        else
+          method_entry?(entry) || class_entry?(entry)
+        end
+      end
+
+      def anonymous_entry?(entry)
+        path = entry.path.to_s.strip
+        path.empty? || path.include?("#<")
+      end
+
+      def method_entry?(entry)
+        [ :instance_method, :class_method ].include?(entry.kind)
+      end
+
+      def class_entry?(entry)
+        [ :class, :module ].include?(entry.kind)
+      end
+
+      def score_for(entry, query)
+        normalized_query = query.to_s.downcase.strip
+        return if normalized_query.empty?
+
+        normalized_path = entry.path.downcase
+        normalized_name = entry.name.downcase
+        normalized_summary = summary_for(entry).downcase
+        segments = normalized_path.split(/::|#|\./)
+
+        score = [
+          (1.0 if normalized_path == normalized_query),
+          (0.99 if normalized_name == normalized_query),
+          (0.95 if segments.include?(normalized_query)),
+          (0.85 if segments.any? { |segment| segment.include?(normalized_query) }),
+          (0.75 if normalized_path.include?(normalized_query)),
+          (0.65 if normalized_summary.split(/[^a-z0-9]+/).include?(normalized_query)),
+          (0.55 if normalized_summary.include?(normalized_query))
+        ].compact.max
+
+        return unless score
+
+        (Float(score) * 100).round / 100.0
+      end
+
+      def summary_for(entry)
+        entry.docstring.to_s.lines.map(&:strip).reject(&:empty?).first.to_s
+      end
+
+      def search_payload(entry, gem_name:, score:)
+        {
+          path: entry.path,
+          gem: gem_name,
+          type: method_entry?(entry) ? "method" : entry.kind.to_s,
+          summary: summary_for(entry),
+          score: score
+        }
+      end
+
+      def normalize_limit(limit)
+        normalized_limit = limit.to_i
+        normalized_limit.positive? ? normalized_limit : 10
       end
     end
   end

--- a/lib/gem_docs/formatters/json.rb
+++ b/lib/gem_docs/formatters/json.rb
@@ -65,7 +65,19 @@ module GemDocs
       end
 
       def search(results:)
-        call(results.map { |result| compact_value(normalize_entry(result)) })
+        payload = results.map do |result|
+          normalized_result = normalize_entry(result)
+          compacted_result = compact_value(
+            path: normalized_result.fetch(:path),
+            gem: normalized_result[:gem],
+            type: normalized_result[:type] || normalized_result[:kind]&.to_s,
+            score: normalized_result[:score]
+          ) || {}
+          compacted_result[:summary] = normalized_result.fetch(:summary, normalized_result[:docstring].to_s).to_s
+          compacted_result
+        end
+
+        call(payload)
       end
     end
   end

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -108,7 +108,30 @@ module GemDocs
       end
 
       def search(results:)
-        build_sections(*results.map { |result| "- #{normalize_entry(result).fetch(:path)}" })
+        normalized_results = results.map do |result|
+          normalized_result = normalize_entry(result)
+          {
+            path: normalized_result.fetch(:path),
+            gem: normalized_result[:gem].to_s,
+            score: format("%.2f", normalized_result.fetch(:score, 0).to_f),
+            summary: normalized_result.fetch(:summary, normalized_result[:docstring].to_s).to_s
+          }
+        end
+        return "" if normalized_results.empty?
+
+        widths = column_widths(
+          normalized_results.map do |result|
+            [ result.fetch(:path), result.fetch(:gem), result.fetch(:score) ]
+          end
+        )
+
+        normalized_results.map do |result|
+          line = format_row(
+            [ result.fetch(:path), result.fetch(:gem), result.fetch(:score) ],
+            widths
+          ).rstrip
+          [ line, result.fetch(:summary) ].reject(&:empty?).join("  ")
+        end.join("\n")
       end
 
       private

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -113,7 +113,7 @@ module GemDocs
           {
             path: normalized_result.fetch(:path),
             gem: normalized_result[:gem].to_s,
-            score: format("%.2f", normalized_result.fetch(:score, 0).to_f),
+            score: format("%.2f", normalized_result[:score].to_f),
             summary: normalized_result.fetch(:summary, normalized_result[:docstring].to_s).to_s
           }
         end

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -15,6 +15,14 @@ module GemDocs
     ?error: SystemCallError
   }
 
+  type search_result = {
+    path: String,
+    gem: String,
+    type: String,
+    summary: String,
+    score: Float
+  }
+
   type entry_kind = :class | :module | :instance_method | :class_method | :constant
   type doc_source = :yard | :rdoc | :source_only | :none
 
@@ -240,7 +248,7 @@ module GemDocs
       def summary: (gem: untyped) -> String
       def classes: (entries: Array[untyped]) -> String
       def lookup: (result: untyped) -> String
-      def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
+      def search: (results: Array[GemDocs::search_result]) -> String
 
       private
 
@@ -257,7 +265,7 @@ module GemDocs
       def summary: (gem: untyped) -> String
       def classes: (entries: Array[untyped]) -> String
       def lookup: (result: untyped) -> String
-      def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
+      def search: (results: Array[GemDocs::search_result]) -> String
     end
 
     class Text < Base
@@ -267,7 +275,7 @@ module GemDocs
       def summary: (gem: untyped) -> String
       def classes: (entries: Array[untyped]) -> String
       def lookup: (result: untyped) -> String
-      def search: (results: Array[GemDocs::DocRegistry::Entry]) -> String
+      def search: (results: Array[GemDocs::search_result]) -> String
 
       private
 
@@ -384,7 +392,24 @@ module GemDocs::Commands
   end
 
   class Search < Base
-    def call: (**untyped) -> Integer
+    def call: (query: String, ?gem: String?, ?scope: String, ?limit: (String | Integer), ?format: String, **untyped) -> Integer
+
+    private
+
+    def doc_registry: -> GemDocs::DocRegistry
+    def installed_specs: -> Array[Gem::Specification]
+    def search_gem: (String query, String gem_name, scope: String, limit: Integer) -> Array[GemDocs::search_result]
+    def search_all_gems: (String query, scope: String, limit: Integer) -> Array[GemDocs::search_result]
+    def safe_ranked_results_for: (String gem_name, String query, scope: String) -> Array[GemDocs::search_result]
+    def ranked_results_for: (GemDocs::DocRegistry::LoadedGem loaded_gem, String query, scope: String) -> Array[GemDocs::search_result]
+    def searchable_entry?: (GemDocs::DocRegistry::Entry entry, String scope) -> bool
+    def anonymous_entry?: (GemDocs::DocRegistry::Entry entry) -> bool
+    def method_entry?: (GemDocs::DocRegistry::Entry entry) -> bool
+    def class_entry?: (GemDocs::DocRegistry::Entry entry) -> bool
+    def score_for: (GemDocs::DocRegistry::Entry entry, String query) -> Float?
+    def summary_for: (GemDocs::DocRegistry::Entry entry) -> String
+    def search_payload: (GemDocs::DocRegistry::Entry entry, gem_name: String, score: Float) -> GemDocs::search_result
+    def normalize_limit: ((String | Integer) limit) -> Integer
   end
 
   class Summary < Base

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -392,6 +392,8 @@ module GemDocs::Commands
   end
 
   class Search < Base
+    PER_GEM_LIMIT: Integer
+
     def call: (query: String, ?gem: String?, ?scope: String, ?limit: (String | Integer), ?format: String, **untyped) -> Integer
 
     private

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -81,11 +81,21 @@ RSpec.describe GemDocs::CLI do
   end
 
   it "dispatches registered commands through dry-cli" do
-    status = described_class.start([ "search" ], out: stdout, err: stderr)
+    stub_const("GemDocs::Commands::Search", Class.new(GemDocs::Commands::Base) do
+      desc "Search gem documentation"
+      argument :query, type: :string
+
+      def call(query:, **)
+        out.puts "searched #{query}"
+        0
+      end
+    end)
+
+    status = described_class.start([ "search", "rack" ], out: stdout, err: stderr)
 
     expect(status).to eq(0)
     expect(stderr.string).to eq("")
-    expect(stdout.string).to eq("search is not implemented yet.\n")
+    expect(stdout.string).to eq("searched rack\n")
   end
 
   it "renders structured JSON for handled command errors" do

--- a/spec/commands/search_spec.rb
+++ b/spec/commands/search_spec.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Commands::Search do
+  def build_entry(path:, kind: :class, visibility: :public, docstring: "")
+    GemDocs::DocRegistry::Entry.new(
+      path: path,
+      name: path.split(/[:#.]/).last,
+      kind: kind,
+      visibility: visibility,
+      docstring: docstring,
+      signature: path,
+      source_location: nil,
+      superclass: nil,
+      doc_source: :yard,
+      tags: {},
+      aliases: []
+    )
+  end
+
+  def build_loaded_gem(name:, version: "1.0.0", doc_source: :yard, objects:)
+    GemDocs::DocRegistry::LoadedGem.new(
+      name: name,
+      version: version,
+      summary: "#{name} fixture",
+      path: "/tmp/#{name}",
+      doc_source: doc_source,
+      objects: objects
+    )
+  end
+
+  def build_spec(name)
+    instance_double(Gem::Specification, name: name)
+  end
+
+  let(:stdout) { StringIO.new }
+  let(:command) { described_class.new }
+  let(:registry) { instance_double(GemDocs::DocRegistry) }
+  let(:config) { instance_double(GemDocs::Config, exclude_gems: []) }
+
+  before do
+    allow(command).to receive(:out).and_return(stdout)
+    allow(command).to receive(:doc_registry).and_return(registry)
+    allow(command).to receive(:config).and_return(config)
+  end
+
+  describe "within a single gem (--gem flag)" do
+    it "returns results sorted by descending score with documented JSON fields" do
+      allow(registry).to receive(:load_gem).with("example").and_return(
+        build_loaded_gem(
+          name: "example",
+          objects: [
+            build_entry(path: "Example::Widget", docstring: "The primary widget."),
+            build_entry(path: "Example::WidgetBuilder", docstring: "Builds widgets.")
+          ]
+        )
+      )
+
+      status = command.call(query: "Widget", gem: "example", format: "json")
+
+      expect(status).to eq(0)
+      payload = JSON.parse(stdout.string)
+
+      expect(payload.size).to eq(2)
+      expect(payload[0]).to include(
+        "path" => "Example::Widget",
+        "gem" => "example",
+        "type" => "class",
+        "summary" => "The primary widget."
+      )
+      expect(payload[1]).to include(
+        "path" => "Example::WidgetBuilder",
+        "gem" => "example",
+        "type" => "class",
+        "summary" => "Builds widgets."
+      )
+      expect(payload[0].fetch("score")).to be > 0
+      expect(payload[1].fetch("score")).to be > 0
+      expect(payload[0].fetch("score")).to be > payload[1].fetch("score")
+    end
+
+    it "respects --limit" do
+      allow(registry).to receive(:load_gem).with("example").and_return(
+        build_loaded_gem(
+          name: "example",
+          objects: [
+            build_entry(path: "Example::Widget"),
+            build_entry(path: "Example::WidgetBuilder"),
+            build_entry(path: "Example::WidgetFactory")
+          ]
+        )
+      )
+
+      status = command.call(query: "Widget", gem: "example", limit: 2, format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string).map { |result| result.fetch("path") }).to eq(
+        [ "Example::Widget", "Example::WidgetBuilder" ]
+      )
+    end
+
+    it "--scope methods returns only method entries" do
+      allow(registry).to receive(:load_gem).with("example").and_return(
+        build_loaded_gem(
+          name: "example",
+          objects: [
+            build_entry(path: "Example::Worker", docstring: "Worker class"),
+            build_entry(path: "Example::Worker#call", kind: :instance_method, docstring: "Calls the worker."),
+            build_entry(path: "Example::Worker.build", kind: :class_method, docstring: "Builds workers.")
+          ]
+        )
+      )
+
+      status = command.call(query: "Worker", gem: "example", scope: "methods", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to all(include("type" => "method"))
+    end
+
+    it "--scope classes returns only class/module entries" do
+      allow(registry).to receive(:load_gem).with("example").and_return(
+        build_loaded_gem(
+          name: "example",
+          objects: [
+            build_entry(path: "Example::Worker", docstring: "Worker class"),
+            build_entry(path: "Example::Worker#call", kind: :instance_method, docstring: "Calls the worker."),
+            build_entry(path: "Example::Workers", kind: :module, docstring: "Workers module.")
+          ]
+        )
+      )
+
+      status = command.call(query: "Worker", gem: "example", scope: "classes", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string).map { |result| result.fetch("path") }).to eq(
+        [ "Example::Worker", "Example::Workers" ]
+      )
+    end
+
+    it "--scope all returns both class and method matches" do
+      allow(registry).to receive(:load_gem).with("example").and_return(
+        build_loaded_gem(
+          name: "example",
+          objects: [
+            build_entry(path: "Example::Worker", docstring: "Worker class"),
+            build_entry(path: "Example::Worker#call", kind: :instance_method, docstring: "Calls the worker.")
+          ]
+        )
+      )
+
+      status = command.call(query: "Worker", gem: "example", scope: "all", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string).map { |result| result.fetch("path") }).to eq(
+        [ "Example::Worker", "Example::Worker#call" ]
+      )
+    end
+
+    it "gives higher score to exact name matches than substring matches" do
+      allow(registry).to receive(:load_gem).with("example").and_return(
+        build_loaded_gem(
+          name: "example",
+          objects: [
+            build_entry(path: "Example::Widget", docstring: "Exact match"),
+            build_entry(path: "Example::WidgetBuilder", docstring: "Partial match")
+          ]
+        )
+      )
+
+      command.call(query: "Widget", gem: "example", format: "json")
+
+      payload = JSON.parse(stdout.string)
+      expect(payload[0].fetch("path")).to eq("Example::Widget")
+      expect(payload[0].fetch("score")).to be > payload[1].fetch("score")
+    end
+
+    it "returns an empty array when nothing matches" do
+      allow(registry).to receive(:load_gem).with("example").and_return(
+        build_loaded_gem(name: "example", objects: [ build_entry(path: "Example::Widget") ])
+      )
+
+      status = command.call(query: "missing", gem: "example", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to eq([])
+    end
+
+    it "raises for an unknown gem" do
+      allow(registry).to receive(:load_gem).with("missing").and_raise(GemDocs::GemNotFound.new("missing"))
+
+      expect { command.call(query: "widget", gem: "missing", format: "json") }
+        .to raise_error(GemDocs::GemNotFound, "Gem 'missing' is not installed")
+    end
+
+    it "handles a gem with doc_source: none gracefully" do
+      allow(registry).to receive(:load_gem).with("empty").and_return(
+        build_loaded_gem(name: "empty", doc_source: :none, objects: [])
+      )
+
+      status = command.call(query: "widget", gem: "empty", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to eq([])
+    end
+  end
+
+  describe "across all gems (no --gem flag)" do
+    before do
+      allow(command).to receive(:installed_specs).and_return([ build_spec("alpha"), build_spec("beta"), build_spec("empty") ])
+    end
+
+    it "returns results from multiple gems and includes a gem field on each result" do
+      allow(registry).to receive(:load_gem).with("alpha").and_return(
+        build_loaded_gem(name: "alpha", objects: [ build_entry(path: "Alpha::Widget", docstring: "Alpha widget") ])
+      )
+      allow(registry).to receive(:load_gem).with("beta").and_return(
+        build_loaded_gem(name: "beta", objects: [ build_entry(path: "Beta::Widget", docstring: "Beta widget") ])
+      )
+      allow(registry).to receive(:load_gem).with("empty").and_return(
+        build_loaded_gem(name: "empty", doc_source: :none, objects: [])
+      )
+
+      status = command.call(query: "Widget", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to match(
+        [
+          include("path" => "Alpha::Widget", "gem" => "alpha"),
+          include("path" => "Beta::Widget", "gem" => "beta")
+        ]
+      )
+    end
+
+    it "caps per-gem contributions at 5 before merging" do
+      alpha_objects = Array.new(6) do |index|
+        build_entry(path: "Alpha::Widget#{index}", docstring: "Alpha widget #{index}")
+      end
+      beta_objects = Array.new(2) do |index|
+        build_entry(path: "Beta::Widget#{index}", docstring: "Beta widget #{index}")
+      end
+
+      allow(registry).to receive(:load_gem).with("alpha").and_return(build_loaded_gem(name: "alpha", objects: alpha_objects))
+      allow(registry).to receive(:load_gem).with("beta").and_return(build_loaded_gem(name: "beta", objects: beta_objects))
+      allow(registry).to receive(:load_gem).with("empty").and_return(
+        build_loaded_gem(name: "empty", doc_source: :none, objects: [])
+      )
+
+      status = command.call(query: "Widget", limit: 10, format: "json")
+
+      expect(status).to eq(0)
+      payload = JSON.parse(stdout.string)
+      expect(payload.count { |result| result.fetch("gem") == "alpha" }).to eq(5)
+      expect(payload.count { |result| result.fetch("gem") == "beta" }).to eq(2)
+    end
+
+    it "skips gems where doc_source is none" do
+      allow(registry).to receive(:load_gem).with("alpha").and_return(
+        build_loaded_gem(name: "alpha", objects: [ build_entry(path: "Alpha::Widget", docstring: "Alpha widget") ])
+      )
+      allow(registry).to receive(:load_gem).with("beta").and_return(
+        build_loaded_gem(name: "beta", doc_source: :none, objects: [])
+      )
+      allow(registry).to receive(:load_gem).with("empty").and_return(
+        build_loaded_gem(name: "empty", doc_source: :none, objects: [])
+      )
+
+      command.call(query: "Widget", format: "json")
+
+      expect(JSON.parse(stdout.string).map { |result| result.fetch("gem") }).to eq([ "alpha" ])
+    end
+
+    it "never raises even if one gem registry is corrupt" do
+      allow(registry).to receive(:load_gem).with("alpha").and_raise(GemDocs::RegistryError.new("broken registry"))
+      allow(registry).to receive(:load_gem).with("beta").and_return(
+        build_loaded_gem(name: "beta", objects: [ build_entry(path: "Beta::Widget", docstring: "Beta widget") ])
+      )
+      allow(registry).to receive(:load_gem).with("empty").and_return(
+        build_loaded_gem(name: "empty", doc_source: :none, objects: [])
+      )
+
+      status = command.call(query: "Widget", format: "json")
+
+      expect(status).to eq(0)
+      expect(JSON.parse(stdout.string)).to match(
+        [
+          include("path" => "Beta::Widget", "gem" => "beta")
+        ]
+      )
+    end
+  end
+end

--- a/spec/commands/search_spec.rb
+++ b/spec/commands/search_spec.rb
@@ -291,5 +291,12 @@ RSpec.describe GemDocs::Commands::Search do
         ]
       )
     end
+
+    it "surfaces non-registry GemDocs errors" do
+      allow(registry).to receive(:load_gem).with("alpha").and_raise(GemDocs::ConfigurationError.new("bad config"))
+
+      expect { command.call(query: "Widget", format: "json") }
+        .to raise_error(GemDocs::ConfigurationError, "bad config")
+    end
   end
 end

--- a/spec/formatters/json_spec.rb
+++ b/spec/formatters/json_spec.rb
@@ -217,33 +217,31 @@ RSpec.describe GemDocs::Formatters::Json do
   end
 
   describe "#search" do
-    it "serializes registry entries without requiring hash access" do
+    it "serializes ranked search results with their documented fields" do
       formatter = described_class.new
 
       output = formatter.search(
         results: [
-          build_entry(path: "Rack::Builder"),
-          build_entry(path: "Rack::Request")
+          { path: "Rack::Builder#call", gem: "rack", type: "method", summary: "Builds Rack apps", score: 0.95 },
+          { path: "Rack::Request", gem: "rack", type: "class", summary: "", score: 0.72 }
         ]
       )
 
       expect(JSON.parse(output)).to eq(
         [
           {
-            "path" => "Rack::Builder",
-            "name" => "Builder",
-            "kind" => "class",
-            "visibility" => "public",
-            "signature" => "Rack::Builder",
-            "doc_source" => "yard"
+            "path" => "Rack::Builder#call",
+            "gem" => "rack",
+            "type" => "method",
+            "summary" => "Builds Rack apps",
+            "score" => 0.95
           },
           {
             "path" => "Rack::Request",
-            "name" => "Request",
-            "kind" => "class",
-            "visibility" => "public",
-            "signature" => "Rack::Request",
-            "doc_source" => "yard"
+            "gem" => "rack",
+            "type" => "class",
+            "summary" => "",
+            "score" => 0.72
           }
         ]
       )

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -147,17 +147,20 @@ RSpec.describe GemDocs::Formatters::Text do
   end
 
   describe "#search" do
-    it "renders registry entries without requiring hash access" do
+    it "renders ranked search rows with gem, score, and summary" do
       formatter = described_class.new
 
       output = formatter.search(
         results: [
-          build_entry(path: "Rack::Builder"),
-          build_entry(path: "Rack::Request")
+          { path: "Rack::Builder#call", gem: "rack", type: "method", summary: "Builds Rack apps", score: 0.95 },
+          { path: "Rack::Request", gem: "rack", type: "class", summary: "Represents a Rack request", score: 0.72 }
         ]
       )
 
-      expect(output).to eq("- Rack::Builder\n- Rack::Request")
+      expect(output).to eq(
+        "Rack::Builder#call  rack  0.95  Builds Rack apps\n" \
+        "Rack::Request       rack  0.72  Represents a Rack request"
+      )
     end
   end
 end

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -162,5 +162,17 @@ RSpec.describe GemDocs::Formatters::Text do
         "Rack::Request       rack  0.72  Represents a Rack request"
       )
     end
+
+    it "treats nil scores as 0.00" do
+      formatter = described_class.new
+
+      output = formatter.search(
+        results: [
+          { path: "Rack::Builder#call", gem: "rack", score: nil, summary: "Builds Rack apps" }
+        ]
+      )
+
+      expect(output).to eq("Rack::Builder#call  rack  0.00  Builds Rack apps")
+    end
   end
 end


### PR DESCRIPTION
## Summary
- implement ranked `gem-docs search` results for single-gem and cross-gem flows
- support `--gem`, `--scope`, and `--limit`, including per-gem caps and corrupt-registry skips
- add formatter, CLI, spec, and type-signature coverage for the new command

Closes #10

## Test Plan
- bundle exec rubocop -a
- bundle exec rspec
- bundle exec steep check