### PR TITLE
feat: add context file generation command

### DIFF
--- a/lib/gem_docs/commands/base.rb
+++ b/lib/gem_docs/commands/base.rb
@@ -27,7 +27,13 @@ module GemDocs
       end
 
       def formatted_error(error, format:)
-        GemDocs::Formatters.for(format).error(error.to_h)
+        formatter_for_error(format).error(error.to_h)
+      end
+
+      def formatter_for_error(format)
+        GemDocs::Formatters.for(format)
+      rescue ArgumentError
+        GemDocs::Formatters.for("text")
       end
     end
   end

--- a/lib/gem_docs/commands/context.rb
+++ b/lib/gem_docs/commands/context.rb
@@ -3,10 +3,90 @@
 module GemDocs
   module Commands
     class Context < Base
-      desc "Show project gem context"
+      OUTPUT_FILES = {
+        "claude" => "CLAUDE.md",
+        "cursor" => ".cursorrules",
+        "windsurf" => ".windsurfrules",
+        "copilot" => File.join(".github", "copilot-instructions.md"),
+        "json" => ".gem-docs-context.json"
+      }.freeze
+      FORMATS = [ *OUTPUT_FILES.keys, "all" ].freeze
 
-      def call(**_kwargs)
-        placeholder("context")
+      desc "Generate project gem context files"
+      option :format,
+             values: FORMATS,
+             default: "all",
+             desc: "Context output format"
+      option :gems, desc: "Comma-separated gem names"
+      option :output_dir, default: ".", desc: "Directory for generated context files"
+
+      def call(format: "all", gems: nil, output_dir: ".", **_kwargs)
+        loaded_gems = resolve_gem_names(gems).map { |gem_name| doc_registry.load_gem(gem_name, version: nil) }
+        output_root = File.expand_path(output_dir, project_root)
+
+        resolve_formats(format).each do |resolved_format|
+          destination = File.join(output_root, OUTPUT_FILES.fetch(resolved_format))
+          ensure_directory(File.dirname(destination))
+          File.write(destination, GemDocs::Formatters::Context.for(resolved_format).call(gems: loaded_gems))
+          out.puts(display_path_for(destination))
+        end
+
+        0
+      end
+
+      private
+
+      def doc_registry
+        @doc_registry ||= GemDocs::DocRegistry.new
+      end
+
+      def project_root
+        Dir.pwd
+      end
+
+      def resolve_formats(format)
+        format == "all" ? OUTPUT_FILES.keys : [ format ]
+      end
+
+      def resolve_gem_names(gems)
+        return lockfile_gem_names if gems.nil? || gems.strip.empty?
+
+        gems.split(",").map(&:strip).reject(&:empty?).uniq
+      end
+
+      def lockfile_gem_names
+        dependency_lines = false
+
+        File.readlines(File.join(project_root, "Gemfile.lock"), chomp: true).filter_map do |line|
+          stripped = line.strip
+          if stripped == "DEPENDENCIES"
+            dependency_lines = true
+            next
+          end
+
+          if dependency_lines && !line.start_with?(" ")
+            dependency_lines = false
+            next
+          end
+
+          next unless dependency_lines
+          next if stripped.empty?
+
+          stripped.split(/[ (!]/).first
+        end.reject { |name| config.exclude_gems.include?(name) }.uniq
+      rescue Errno::ENOENT
+        raise GemDocs::ConfigurationError.new("Gemfile.lock not found in #{project_root}")
+      end
+
+      def display_path_for(destination)
+        prefix = "#{project_root}/"
+        destination.start_with?(prefix) ? destination.delete_prefix(prefix) : destination
+      end
+
+      def ensure_directory(path)
+        parent = File.dirname(path)
+        ensure_directory(parent) unless Dir.exist?(parent)
+        Dir.mkdir(path) unless Dir.exist?(path)
       end
     end
   end

--- a/lib/gem_docs/commands/context.rb
+++ b/lib/gem_docs/commands/context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "bundler"
+
 module GemDocs
   module Commands
     class Context < Base
@@ -55,25 +57,12 @@ module GemDocs
       end
 
       def lockfile_gem_names
-        dependency_lines = false
-
-        File.readlines(File.join(project_root, "Gemfile.lock"), chomp: true).filter_map do |line|
-          stripped = line.strip
-          if stripped == "DEPENDENCIES"
-            dependency_lines = true
-            next
-          end
-
-          if dependency_lines && !line.start_with?(" ")
-            dependency_lines = false
-            next
-          end
-
-          next unless dependency_lines
-          next if stripped.empty?
-
-          stripped.split(/[ (!]/).first
-        end.reject { |name| config.exclude_gems.include?(name) }.uniq
+        Bundler::LockfileParser
+          .new(Bundler.read_file(File.join(project_root, "Gemfile.lock")))
+          .dependencies
+          .keys
+          .reject { |name| config.exclude_gems.include?(name) }
+          .uniq
       rescue Errno::ENOENT
         raise GemDocs::ConfigurationError.new("Gemfile.lock not found in #{project_root}")
       end

--- a/lib/gem_docs/formatters/context/base.rb
+++ b/lib/gem_docs/formatters/context/base.rb
@@ -4,6 +4,11 @@ module GemDocs
   module Formatters
     module Context
       class Base < GemDocs::Formatters::Base
+        MAX_SUMMARY_LENGTH = 140
+        MAX_CLASSES = 6
+        MAX_ENTRY_POINTS = 3
+        MAX_LIST_ITEM_LENGTH = 48
+
         private
 
         def documented_gems(gems)
@@ -25,12 +30,26 @@ module GemDocs
         def gem_sections(gems)
           documented_gems(gems).map do |gem|
             lines = [ "## #{gem[:name]} (#{gem[:version]})" ]
-            lines << "- Summary: #{gem[:summary]}" if gem[:summary]
+            lines << "- Summary: #{truncate(gem[:summary], MAX_SUMMARY_LENGTH)}" if gem[:summary]
             lines << "- Documentation: #{gem[:doc_source]}"
-            lines << "- Classes: #{gem[:classes].join(', ')}" if gem[:classes]
-            lines << "- Entry points: #{gem[:entry_points].join(', ')}" if gem[:entry_points]
+            lines << "- Classes: #{format_list(gem[:classes], limit: MAX_CLASSES)}" if gem[:classes]
+            lines << "- Entry points: #{format_list(gem[:entry_points], limit: MAX_ENTRY_POINTS)}" if gem[:entry_points]
             lines.join("\n")
           end
+        end
+
+        def format_list(values, limit:)
+          items = Array(values).take(limit).map { |value| truncate(value, MAX_LIST_ITEM_LENGTH) }
+          overflow = Array(values).length - items.length
+          items << "... (+#{overflow} more)" if overflow.positive?
+          items.join(", ")
+        end
+
+        def truncate(value, limit)
+          text = value.to_s.strip
+          return text if text.length <= limit
+
+          "#{text[0, limit - 1]}…"
         end
       end
     end

--- a/sig/deps/bundler.rbs
+++ b/sig/deps/bundler.rbs
@@ -1,0 +1,12 @@
+module Bundler
+  def self.read_file: (String path) -> String
+
+  class Dependency
+    attr_reader name: String
+  end
+
+  class LockfileParser
+    def initialize: (String lockfile) -> void
+    def dependencies: -> Hash[String, Dependency]
+  end
+end

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -298,12 +298,19 @@ module GemDocs
       def self.for: (String | Symbol format) -> Base
 
       class Base < GemDocs::Formatters::Base
+        MAX_SUMMARY_LENGTH: Integer
+        MAX_CLASSES: Integer
+        MAX_ENTRY_POINTS: Integer
+        MAX_LIST_ITEM_LENGTH: Integer
+
         def call: (gems: Array[untyped]) -> String
 
         private
 
         def documented_gems: (Array[untyped] gems) -> Array[Hash[Symbol, untyped]]
         def gem_sections: (Array[untyped] gems) -> Array[String]
+        def format_list: (untyped values, limit: Integer) -> String
+        def truncate: (untyped value, Integer limit) -> String
       end
 
       class Claude < Base
@@ -363,7 +370,20 @@ module GemDocs::Commands
   end
 
   class Context < Base
-    def call: (**untyped) -> Integer
+    OUTPUT_FILES: Hash[String, String]
+    FORMATS: Array[String]
+
+    def call: (?format: String, ?gems: String?, ?output_dir: String, **untyped) -> Integer
+
+    private
+
+    def doc_registry: -> GemDocs::DocRegistry
+    def project_root: -> String
+    def resolve_formats: (String format) -> Array[String]
+    def resolve_gem_names: (String? gems) -> Array[String]
+    def lockfile_gem_names: -> Array[String]
+    def display_path_for: (String destination) -> String
+    def ensure_directory: (String path) -> void
   end
 
   class List < Base

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -352,6 +352,7 @@ module GemDocs::Commands
 
     def config: -> GemDocs::Config
     def formatted_error: (GemDocs::Error error, format: String) -> String
+    def formatter_for_error: (String format) -> GemDocs::Formatters::Base
   end
 
   class Classes < Base

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -175,6 +175,23 @@ RSpec.describe GemDocs::CLI do
     )
   end
 
+  it "falls back to text errors when a command uses a non-shared format option" do
+    registry = instance_double(GemDocs::DocRegistry)
+    allow(GemDocs::DocRegistry).to receive(:new).and_return(registry)
+    allow(registry).to receive(:load_gem).with("missing-gem", version: nil)
+      .and_raise(GemDocs::GemNotFound.new("missing-gem"))
+
+    status = described_class.start(
+      [ "context", "--format", "claude", "--gems", "missing-gem" ],
+      out: stdout,
+      err: stderr
+    )
+
+    expect(status).to eq(1)
+    expect(stdout.string).to eq("")
+    expect(stderr.string).to eq("Gem 'missing-gem' is not installed\n")
+  end
+
   it "accepts --version for the summary command" do
     registry = instance_double(
       GemDocs::DocRegistry,

--- a/spec/commands/context_spec.rb
+++ b/spec/commands/context_spec.rb
@@ -124,6 +124,36 @@ RSpec.describe GemDocs::Commands::Context do
     expect(registry).to have_received(:load_gem).with("rack", version: nil)
   end
 
+  it "normalizes non-rubygems lockfile dependencies before loading docs" do
+    File.write(
+      File.join(project_root, "Gemfile.lock"),
+      <<~LOCK
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            path-gem (0.1.0)
+            rack (3.1.0)
+
+        PATH
+          remote: vendor/path-gem
+          specs:
+            path-gem (0.1.0)
+
+        DEPENDENCIES
+          path-gem!
+          rack
+      LOCK
+    )
+
+    allow(registry).to receive(:load_gem).with("path-gem", version: nil).and_return(build_loaded_gem(name: "path-gem"))
+    allow(registry).to receive(:load_gem).with("rack", version: nil).and_return(build_loaded_gem(name: "rack"))
+
+    command.call(format: "claude", output_dir: "context")
+
+    expect(registry).to have_received(:load_gem).with("path-gem", version: nil)
+    expect(registry).to have_received(:load_gem).with("rack", version: nil)
+  end
+
   it "prefers an explicit gem list over Gemfile.lock discovery" do
     File.write(
       File.join(project_root, "Gemfile.lock"),

--- a/spec/commands/context_spec.rb
+++ b/spec/commands/context_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "stringio"
+require "tmpdir"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Commands::Context do
+  def build_entry(path:)
+    GemDocs::DocRegistry::Entry.new(
+      path: path,
+      name: path.split(/[:#.]/).last,
+      kind: :class,
+      visibility: :public,
+      docstring: "",
+      signature: path,
+      source_location: nil,
+      superclass: nil,
+      doc_source: :yard,
+      tags: {},
+      aliases: []
+    )
+  end
+
+  def build_loaded_gem(
+    name:,
+    version: "1.0.0",
+    summary: "Fixture summary",
+    doc_source: :yard,
+    classes: [],
+    entry_points: []
+  )
+    GemDocs::DocRegistry::LoadedGem.new(
+      name: name,
+      version: version,
+      summary: summary,
+      description: summary,
+      path: "/tmp/#{name}",
+      doc_source: doc_source,
+      objects: classes.map { |path| build_entry(path: path) },
+      entry_points: entry_points
+    )
+  end
+
+  let(:stdout) { StringIO.new }
+  let(:command) { described_class.new }
+  let(:registry) { instance_double(GemDocs::DocRegistry) }
+  let(:project_root) { Dir.mktmpdir }
+
+  before do
+    allow(command).to receive(:out).and_return(stdout)
+    allow(command).to receive(:doc_registry).and_return(registry)
+    allow(command).to receive(:project_root).and_return(project_root)
+  end
+
+  after do
+    FileUtils.remove_entry(project_root)
+  end
+
+  it "writes the selected Claude context file with documented gems only" do
+    allow(registry).to receive(:load_gem).with("rack", version: nil).and_return(
+      build_loaded_gem(
+        name: "rack",
+        version: "3.1.0",
+        summary: "HTTP toolkit",
+        classes: [ "Rack::Builder", "Rack::Request" ],
+        entry_points: [ "Rack::Builder.new" ]
+      )
+    )
+    allow(registry).to receive(:load_gem).with("undocumented", version: nil).and_return(
+      build_loaded_gem(name: "undocumented", doc_source: :none)
+    )
+
+    status = command.call(format: "claude", gems: "rack, undocumented", output_dir: "generated")
+
+    expect(status).to eq(0)
+    expect(stdout.string).to include("generated/CLAUDE.md")
+
+    output = File.read(File.join(project_root, "generated", "CLAUDE.md"))
+    expect(output).to include("# Gem documentation context")
+    expect(output).to include("## rack (3.1.0)")
+    expect(output).to include("- Entry points: Rack::Builder.new")
+    expect(output).not_to include("undocumented")
+  end
+
+  it "writes every supported context output when format is all" do
+    allow(registry).to receive(:load_gem).with("rack", version: nil).and_return(
+      build_loaded_gem(name: "rack", entry_points: [ "Rack::Builder.new" ])
+    )
+
+    status = command.call(format: "all", gems: "rack", output_dir: "context")
+
+    expect(status).to eq(0)
+    expect(File).to exist(File.join(project_root, "context", "CLAUDE.md"))
+    expect(File).to exist(File.join(project_root, "context", ".cursorrules"))
+    expect(File).to exist(File.join(project_root, "context", ".windsurfrules"))
+    expect(File).to exist(File.join(project_root, "context", ".github", "copilot-instructions.md"))
+    expect(File).to exist(File.join(project_root, "context", ".gem-docs-context.json"))
+  end
+
+  it "discovers project gems from Gemfile.lock when --gems is omitted" do
+    File.write(
+      File.join(project_root, "Gemfile.lock"),
+      <<~LOCK
+        GEM
+          specs:
+            faraday (2.12.0)
+            rack (3.1.0)
+
+        DEPENDENCIES
+          faraday
+          rack
+      LOCK
+    )
+
+    allow(registry).to receive(:load_gem).with("faraday", version: nil).and_return(build_loaded_gem(name: "faraday"))
+    allow(registry).to receive(:load_gem).with("rack", version: nil).and_return(build_loaded_gem(name: "rack"))
+
+    command.call(format: "claude", output_dir: "context")
+
+    expect(registry).to have_received(:load_gem).with("faraday", version: nil)
+    expect(registry).to have_received(:load_gem).with("rack", version: nil)
+  end
+
+  it "prefers an explicit gem list over Gemfile.lock discovery" do
+    File.write(
+      File.join(project_root, "Gemfile.lock"),
+      <<~LOCK
+        GEM
+          specs:
+            faraday (2.12.0)
+
+        DEPENDENCIES
+          faraday
+      LOCK
+    )
+
+    allow(registry).to receive(:load_gem).with("rack", version: nil).and_return(build_loaded_gem(name: "rack"))
+
+    command.call(format: "claude", gems: "rack", output_dir: "context")
+
+    expect(registry).to have_received(:load_gem).with("rack", version: nil)
+    expect(registry).not_to have_received(:load_gem).with("faraday", version: nil)
+  end
+
+  it "raises a configuration error when Gemfile.lock is missing for discovery" do
+    expect { command.call(format: "claude", output_dir: "context") }
+      .to raise_error(GemDocs::ConfigurationError, /Gemfile\.lock not found/)
+  end
+end

--- a/spec/formatters/context_spec.rb
+++ b/spec/formatters/context_spec.rb
@@ -78,4 +78,23 @@ RSpec.describe GemDocs::Formatters::Context do
 
     expect(JSON.parse(output)).to eq({})
   end
+
+  it "keeps Claude output compact for larger projects" do
+    large_project = Array.new(20) do |index|
+      {
+        name: "gem-#{index}",
+        version: "1.0.#{index}",
+        summary: "A" * 250,
+        doc_source: :yard,
+        classes: Array.new(12) { |class_index| "Gem#{index}::Class#{class_index}" },
+        entry_points: Array.new(5) { |entry_index| "Gem#{index}::Class#{entry_index}#call" }
+      }
+    end
+
+    output = described_class.for("claude").call(gems: large_project)
+
+    expect(output).to include("- Summary:")
+    expect(output).to include("- Entry points:")
+    expect(output.bytesize).to be < 10_000
+  end
 end


### PR DESCRIPTION
## Summary
- implement `gem-docs context` with `--format`, `--gems`, and `--output-dir`
- generate Claude, Cursor, Windsurf, Copilot, and JSON context files from explicit gems or `Gemfile.lock`
- keep generated Claude context compact and omit gems without documentation

Closes #11

## Test Plan
- bundle exec rubocop -a
- bundle exec rspec
- bundle exec steep check