### PR TITLE
feat: add optional MCP server wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# gem-docs
+
+CLI-first gem documentation lookup for local Ruby projects, with an optional MCP server wrapper.
+
+## CLI
+
+```bash
+bundle exec exe/gem-docs list
+bundle exec exe/gem-docs summary faraday --format json
+bundle exec exe/gem-docs lookup Faraday::Connection#get --gem faraday
+bundle exec exe/gem-docs search Widget --scope classes
+```
+
+## MCP server
+
+The MCP path is optional and only loads `fast-mcp` when you start the server.
+
+### STDIO mode
+
+```bash
+bundle exec exe/gem-docs server
+# or
+bundle exec exe/gem-docs-server
+```
+
+### HTTP mode
+
+```bash
+bundle exec exe/gem-docs server --mode http --port 6040
+bundle exec exe/gem-docs server --mode http --port 6040 --bind-all
+```
+
+HTTP mode serves MCP endpoints under `/mcp`.
+
+### Exposed MCP tools
+
+- `list`
+- `summary`
+- `classes`
+- `lookup`
+- `search`
+
+Each tool delegates to the same command layer as the CLI and returns the CLI JSON payload as MCP tool output.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ bundle exec exe/gem-docs search Widget --scope classes
 
 The MCP path is optional and only loads `fast-mcp` when you start the server.
 
+Install the optional dependency before using the server entrypoints:
+
+```ruby
+gem "fast-mcp"
+```
+
+Then run `bundle install`.
+
 ### STDIO mode
 
 ```bash

--- a/lib/gem_docs/commands/server.rb
+++ b/lib/gem_docs/commands/server.rb
@@ -4,12 +4,30 @@ module GemDocs
   module Commands
     class Server < Base
       desc "Start the MCP server"
-      argument :args, type: :array
+      option :mode,
+             values: %w[stdio http],
+             default: "stdio",
+             desc: "Server transport mode"
+      option :port,
+             default: "6040",
+             desc: "HTTP port"
+      option :bind_all,
+             type: :boolean,
+             default: false,
+             desc: "Bind HTTP mode to 0.0.0.0"
 
-      def call(args: [], **_kwargs)
+      def call(mode: "stdio", port: "6040", bind_all: false, **_kwargs)
         require "gem_docs/mcp/server"
 
-        GemDocs::MCP::Server.start(args, out: out, err: err)
+        GemDocs::MCP::Server.start(server_arguments(mode: mode, port: port, bind_all: bind_all), out: out, err: err)
+      end
+
+      private
+
+      def server_arguments(mode:, port:, bind_all:)
+        arguments = [ "--mode", mode.to_s, "--port", port.to_s ]
+        arguments << "--bind-all" if bind_all
+        arguments
       end
     end
   end

--- a/lib/gem_docs/mcp/command_tool.rb
+++ b/lib/gem_docs/mcp/command_tool.rb
@@ -39,8 +39,10 @@ module GemDocs
         command.define_singleton_method(:out) { stdout }
         command.define_singleton_method(:err) { stderr }
 
+        command_kwargs = kwargs.merge(format: "json")
+
         status = begin
-          command.call(**kwargs, format: "json")
+          command.call(**command_kwargs)
         rescue GemDocs::Error => e
           command.render_command_error(e, format: "json")
         rescue StandardError => e

--- a/lib/gem_docs/mcp/command_tool.rb
+++ b/lib/gem_docs/mcp/command_tool.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+module GemDocs
+  module MCP
+    class CommandTool < ::FastMcp::Tool
+      class << self
+        def command(command_class = nil)
+          return @command_class if command_class.nil?
+
+          @command_class = command_class
+        end
+      end
+
+      def call(**kwargs)
+        response = execute_command(**command_arguments(**kwargs))
+
+        {
+          content: [ { type: "text", text: response.fetch(:body) } ],
+          isError: !response.fetch(:success)
+        }
+      end
+
+      private
+
+      def command_arguments(**kwargs)
+        kwargs
+      end
+
+      def execute_command(**kwargs)
+        stdout = StringIO.new
+        stderr = StringIO.new
+        command_class = self.class.command
+        raise "MCP tool command class is not configured" if command_class.nil?
+
+        command = command_class.new
+        command.define_singleton_method(:out) { stdout }
+        command.define_singleton_method(:err) { stderr }
+
+        status = begin
+          command.call(**kwargs, format: "json")
+        rescue GemDocs::Error => e
+          command.render_command_error(e, format: "json")
+        end
+
+        {
+          success: status.zero?,
+          body: status.zero? ? stdout.string : stderr.string
+        }
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp/command_tool.rb
+++ b/lib/gem_docs/mcp/command_tool.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "stringio"
 
 module GemDocs
@@ -42,6 +43,9 @@ module GemDocs
           command.call(**kwargs, format: "json")
         rescue GemDocs::Error => e
           command.render_command_error(e, format: "json")
+        rescue StandardError => e
+          stderr.puts(JSON.generate(error: "internal_error", message: e.message))
+          1
         end
 
         {

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -5,7 +5,6 @@ require "optparse"
 require "socket"
 require "stringio"
 require "timeout"
-require "timeout"
 
 module GemDocs
   module MCP

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -148,7 +148,7 @@ module GemDocs
           host: host,
           port: port,
           server_protocol: server_protocol || "HTTP/1.1",
-          remote_addr: socket.peeraddr(false)[3]
+          remote_addr: remote_addr_for(socket)
         )
 
         status, response_headers, response_body = app.call(env)
@@ -251,6 +251,13 @@ module GemDocs
         env
       end
       private_class_method :rack_env
+
+      def self.remote_addr_for(socket)
+        socket.peeraddr(false)[3]
+      rescue IOError, SystemCallError
+        "unknown"
+      end
+      private_class_method :remote_addr_for
 
       def self.write_http_response(socket, status, headers, body)
         response_body = +""

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -39,7 +39,8 @@ module GemDocs
             server,
             host: options.fetch(:bind_all) ? "0.0.0.0" : "127.0.0.1",
             port: options.fetch(:port),
-            out: out
+            out: out,
+            err: err
           )
         end
 
@@ -97,22 +98,25 @@ module GemDocs
       end
       private_class_method :parse_options
 
-      def self.run_http(server, host:, port:, out:)
+      def self.run_http(server, host:, port:, out:, err:)
         app = server.start_rack(
-          lambda { |_env| not_found_response },
+          lambda { |env| not_found_response(env["PATH_INFO"]) },
           path_prefix: "/mcp",
           localhost_only: host != "0.0.0.0"
         )
-        out.puts "gem-docs MCP server listening on http://#{host}:#{port}/mcp"
-        serve_http(app, host: host, port: port)
+        serve_http(app, host: host, port: port, out: out)
         0
       rescue Interrupt
         0
+      rescue Errno::EACCES, Errno::EADDRINUSE, Errno::EADDRNOTAVAIL, SocketError => e
+        err.puts "gem-docs MCP HTTP server failed to bind #{host}:#{port}: #{e.message}"
+        1
       end
       private_class_method :run_http
 
-      def self.serve_http(app, host:, port:)
+      def self.serve_http(app, host:, port:, out:)
         TCPServer.open(host, port) do |listener|
+          out.puts "gem-docs MCP server listening on http://#{host}:#{port}/mcp"
           loop do
             socket = listener.accept
             handle_http_connection(socket, app, host: host, port: port)
@@ -132,7 +136,14 @@ module GemDocs
         return if request_line.nil?
 
         method, request_target, server_protocol = request_line.strip.split(" ", 3)
-        return write_http_response(socket, 400, json_headers, [ JSON.generate(error: "Bad Request") ]) if method.nil? || request_target.nil?
+        if method.nil? || request_target.nil?
+          return write_http_response(
+            socket,
+            400,
+            json_headers,
+            [ JSON.generate(error: "bad_request", message: "Malformed HTTP request line") ]
+          )
+        end
 
         headers = read_http_headers(socket)
         body = read_http_body(socket, headers)
@@ -170,7 +181,10 @@ module GemDocs
           key, value = stripped_line.split(":", 2)
           next if key.nil?
 
-          headers[key] = value.to_s.strip
+          normalized_key = key.strip.downcase
+          next if normalized_key.empty?
+
+          headers[normalized_key] = value.to_s.strip
         end
 
         headers
@@ -178,7 +192,7 @@ module GemDocs
       private_class_method :read_http_headers
 
       def self.read_http_body(socket, headers)
-        content_length = headers.fetch("Content-Length", "0").to_i
+        content_length = headers.fetch("content-length", "0").to_i
         raise RequestTooLargeError, "Request body exceeds #{MAX_REQUEST_BODY_BYTES} bytes" if content_length > MAX_REQUEST_BODY_BYTES
         return "" unless content_length.positive?
 
@@ -239,9 +253,9 @@ module GemDocs
 
         headers.each do |key, value|
           case key
-          when "Content-Length"
+          when "content-length"
             env["CONTENT_LENGTH"] = value
-          when "Content-Type"
+          when "content-type"
             env["CONTENT_TYPE"] = value
           else
             env["HTTP_#{key.upcase.tr('-', '_')}"] = value
@@ -285,11 +299,11 @@ module GemDocs
       end
       private_class_method :http_status_reason
 
-      def self.not_found_response
+      def self.not_found_response(path)
         [
           404,
           json_headers,
-          [ JSON.generate(error: "Not Found") ]
+          [ JSON.generate(error: "not_found", message: "No MCP endpoint matches #{path}") ]
         ]
       end
       private_class_method :not_found_response

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -8,14 +8,18 @@ require "stringio"
 module GemDocs
   module MCP
     class Server
+      RequestTooLargeError = Class.new(StandardError)
+
       DEFAULT_MODE = "stdio"
       DEFAULT_PORT = 6040
+      MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024
       HTTP_STATUS_REASONS = {
         200 => "OK",
         400 => "Bad Request",
         403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
+        413 => "Payload Too Large",
         500 => "Internal Server Error"
       }.freeze
 
@@ -108,6 +112,10 @@ module GemDocs
           loop do
             socket = listener.accept
             handle_http_connection(socket, app, host: host, port: port)
+          rescue Interrupt
+            raise
+          rescue StandardError => e
+            warn "gem-docs MCP HTTP server error: #{e.class}: #{e.message}"
           ensure
             socket&.close unless socket&.closed?
           end
@@ -120,6 +128,8 @@ module GemDocs
         return if request_line.nil?
 
         method, request_target, server_protocol = request_line.strip.split(" ", 3)
+        return write_http_response(socket, 400, json_headers, [ JSON.generate(error: "Bad Request") ]) if method.nil? || request_target.nil?
+
         headers = read_http_headers(socket)
         body = read_http_body(socket, headers)
         path, query = request_target.to_s.split("?", 2)
@@ -138,6 +148,8 @@ module GemDocs
 
         status, response_headers, response_body = app.call(env)
         write_http_response(socket, status, response_headers, response_body)
+      rescue RequestTooLargeError
+        write_http_response(socket, 413, json_headers, [ JSON.generate(error: "Payload Too Large") ])
       end
       private_class_method :handle_http_connection
 
@@ -158,6 +170,7 @@ module GemDocs
 
       def self.read_http_body(socket, headers)
         content_length = headers.fetch("Content-Length", "0").to_i
+        raise RequestTooLargeError, "Request body exceeds #{MAX_REQUEST_BODY_BYTES} bytes" if content_length > MAX_REQUEST_BODY_BYTES
         return "" unless content_length.positive?
 
         socket.read(content_length).to_s
@@ -227,11 +240,16 @@ module GemDocs
       def self.not_found_response
         [
           404,
-          { "Content-Type" => "application/json" },
+          json_headers,
           [ JSON.generate(error: "Not Found") ]
         ]
       end
       private_class_method :not_found_response
+
+      def self.json_headers
+        { "Content-Type" => "application/json" }
+      end
+      private_class_method :json_headers
     end
   end
 end

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -1,13 +1,52 @@
 # frozen_string_literal: true
 
+require "json"
+require "optparse"
+require "socket"
+require "stringio"
+
 module GemDocs
   module MCP
     class Server
-      def self.start(_arguments = [], out: $stdout, err: $stderr)
+      DEFAULT_MODE = "stdio"
+      DEFAULT_PORT = 6040
+      HTTP_STATUS_REASONS = {
+        200 => "OK",
+        400 => "Bad Request",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        500 => "Internal Server Error"
+      }.freeze
+
+      def self.start(arguments = [], out: $stdout, err: $stderr)
         return 1 unless load_fast_mcp(err)
 
-        out.puts "gem-docs-server placeholder loaded"
+        options = parse_options(arguments, err: err)
+        return 1 unless options
+
+        server = build_fast_mcp_server
+        if options.fetch(:mode) == "http"
+          return run_http(
+            server,
+            host: options.fetch(:bind_all) ? "0.0.0.0" : "127.0.0.1",
+            port: options.fetch(:port),
+            out: out
+          )
+        end
+
+        server.start
         0
+      end
+
+      def self.build_fast_mcp_server
+        require "fast_mcp"
+        require "gem_docs/mcp/command_tool"
+        require "gem_docs/mcp/tools"
+
+        FastMcp::Server.new(name: "gem-docs", version: GemDocs::VERSION).tap do |server|
+          server.register_tools(*GemDocs::MCP::Tools.all)
+        end
       end
 
       def self.load_fast_mcp(err)
@@ -22,6 +61,177 @@ module GemDocs
       end
 
       private_class_method :load_fast_mcp
+
+      def self.parse_options(arguments, err:)
+        options = {
+          mode: DEFAULT_MODE,
+          port: DEFAULT_PORT,
+          bind_all: false
+        }
+
+        parser = OptionParser.new do |opts|
+          opts.on("--mode MODE", %w[stdio http], "Server transport mode") do |mode|
+            options[:mode] = mode
+          end
+          opts.on("--port PORT", Integer, "HTTP port") do |port|
+            options[:port] = port
+          end
+          opts.on("--bind-all", "Bind HTTP mode to 0.0.0.0") do
+            options[:bind_all] = true
+          end
+        end
+
+        parser.parse!(Array(arguments))
+        options
+      rescue OptionParser::ParseError => e
+        err.puts e.message
+        nil
+      end
+      private_class_method :parse_options
+
+      def self.run_http(server, host:, port:, out:)
+        app = server.start_rack(
+          lambda { |_env| not_found_response },
+          path_prefix: "/mcp",
+          localhost_only: host != "0.0.0.0"
+        )
+        out.puts "gem-docs MCP server listening on http://#{host}:#{port}/mcp"
+        serve_http(app, host: host, port: port)
+        0
+      rescue Interrupt
+        0
+      end
+      private_class_method :run_http
+
+      def self.serve_http(app, host:, port:)
+        TCPServer.open(host, port) do |listener|
+          loop do
+            socket = listener.accept
+            handle_http_connection(socket, app, host: host, port: port)
+          ensure
+            socket&.close unless socket&.closed?
+          end
+        end
+      end
+      private_class_method :serve_http
+
+      def self.handle_http_connection(socket, app, host:, port:)
+        request_line = socket.gets("\r\n")
+        return if request_line.nil?
+
+        method, request_target, server_protocol = request_line.strip.split(" ", 3)
+        headers = read_http_headers(socket)
+        body = read_http_body(socket, headers)
+        path, query = request_target.to_s.split("?", 2)
+
+        env = rack_env(
+          method: method,
+          path: path.empty? ? "/" : path,
+          query: query.to_s,
+          headers: headers,
+          body: body,
+          host: host,
+          port: port,
+          server_protocol: server_protocol || "HTTP/1.1",
+          remote_addr: socket.peeraddr(false)[3]
+        )
+
+        status, response_headers, response_body = app.call(env)
+        write_http_response(socket, status, response_headers, response_body)
+      end
+      private_class_method :handle_http_connection
+
+      def self.read_http_headers(socket)
+        headers = {} # @type var headers: Hash[String, String]
+
+        while (line = socket.gets("\r\n"))
+          stripped_line = line.chomp("\r\n")
+          break if stripped_line.empty?
+
+          key, value = stripped_line.split(":", 2)
+          headers[key] = value.to_s.strip
+        end
+
+        headers
+      end
+      private_class_method :read_http_headers
+
+      def self.read_http_body(socket, headers)
+        content_length = headers.fetch("Content-Length", "0").to_i
+        return "" unless content_length.positive?
+
+        socket.read(content_length).to_s
+      end
+      private_class_method :read_http_body
+
+      def self.rack_env(method:, path:, query:, headers:, body:, host:, port:, server_protocol:, remote_addr:)
+        env = {
+          "REQUEST_METHOD" => method,
+          "SCRIPT_NAME" => "",
+          "PATH_INFO" => path,
+          "QUERY_STRING" => query,
+          "SERVER_NAME" => host,
+          "SERVER_PORT" => port.to_s,
+          "SERVER_PROTOCOL" => server_protocol,
+          "REMOTE_ADDR" => remote_addr,
+          "rack.version" => [ 3, 0 ],
+          "rack.url_scheme" => "http",
+          "rack.input" => StringIO.new(body),
+          "rack.errors" => $stderr,
+          "rack.multithread" => false,
+          "rack.multiprocess" => false,
+          "rack.run_once" => false
+        }
+
+        headers.each do |key, value|
+          case key
+          when "Content-Length"
+            env["CONTENT_LENGTH"] = value
+          when "Content-Type"
+            env["CONTENT_TYPE"] = value
+          else
+            env["HTTP_#{key.upcase.tr('-', '_')}"] = value
+          end
+        end
+
+        env
+      end
+      private_class_method :rack_env
+
+      def self.write_http_response(socket, status, headers, body)
+        response_body = +""
+        body.each do |chunk|
+          response_body << chunk.to_s
+        end
+
+        normalized_headers = headers.transform_keys(&:to_s)
+        normalized_headers["Content-Length"] ||= response_body.bytesize.to_s
+        normalized_headers["Connection"] ||= "close"
+
+        socket.write("HTTP/1.1 #{status} #{http_status_reason(status)}\r\n")
+        normalized_headers.each do |key, value|
+          socket.write("#{key}: #{value}\r\n")
+        end
+        socket.write("\r\n")
+        socket.write(response_body)
+      ensure
+        body.close if body.respond_to?(:close)
+      end
+      private_class_method :write_http_response
+
+      def self.http_status_reason(status)
+        HTTP_STATUS_REASONS.fetch(status.to_i, "OK")
+      end
+      private_class_method :http_status_reason
+
+      def self.not_found_response
+        [
+          404,
+          { "Content-Type" => "application/json" },
+          [ JSON.generate(error: "Not Found") ]
+        ]
+      end
+      private_class_method :not_found_response
     end
   end
 end

--- a/lib/gem_docs/mcp/server.rb
+++ b/lib/gem_docs/mcp/server.rb
@@ -4,21 +4,26 @@ require "json"
 require "optparse"
 require "socket"
 require "stringio"
+require "timeout"
+require "timeout"
 
 module GemDocs
   module MCP
     class Server
       RequestTooLargeError = Class.new(StandardError)
+      RequestTimeoutError = Class.new(StandardError)
 
       DEFAULT_MODE = "stdio"
       DEFAULT_PORT = 6040
       MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024
+      SOCKET_READ_TIMEOUT_SECONDS = 30
       HTTP_STATUS_REASONS = {
         200 => "OK",
         400 => "Bad Request",
         403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
+        408 => "Request Timeout",
         413 => "Payload Too Large",
         500 => "Internal Server Error"
       }.freeze
@@ -124,7 +129,7 @@ module GemDocs
       private_class_method :serve_http
 
       def self.handle_http_connection(socket, app, host:, port:)
-        request_line = socket.gets("\r\n")
+        request_line = read_http_line(socket)
         return if request_line.nil?
 
         method, request_target, server_protocol = request_line.strip.split(" ", 3)
@@ -133,10 +138,11 @@ module GemDocs
         headers = read_http_headers(socket)
         body = read_http_body(socket, headers)
         path, query = request_target.to_s.split("?", 2)
+        resolved_path = path.to_s.empty? ? "/" : path.to_s
 
         env = rack_env(
           method: method,
-          path: path.empty? ? "/" : path,
+          path: resolved_path,
           query: query.to_s,
           headers: headers,
           body: body,
@@ -148,6 +154,8 @@ module GemDocs
 
         status, response_headers, response_body = app.call(env)
         write_http_response(socket, status, response_headers, response_body)
+      rescue RequestTimeoutError
+        write_http_response(socket, 408, json_headers, [ JSON.generate(error: "Request Timeout") ])
       rescue RequestTooLargeError
         write_http_response(socket, 413, json_headers, [ JSON.generate(error: "Payload Too Large") ])
       end
@@ -156,11 +164,13 @@ module GemDocs
       def self.read_http_headers(socket)
         headers = {} # @type var headers: Hash[String, String]
 
-        while (line = socket.gets("\r\n"))
+        while (line = read_http_line(socket))
           stripped_line = line.chomp("\r\n")
           break if stripped_line.empty?
 
           key, value = stripped_line.split(":", 2)
+          next if key.nil?
+
           headers[key] = value.to_s.strip
         end
 
@@ -173,9 +183,41 @@ module GemDocs
         raise RequestTooLargeError, "Request body exceeds #{MAX_REQUEST_BODY_BYTES} bytes" if content_length > MAX_REQUEST_BODY_BYTES
         return "" unless content_length.positive?
 
-        socket.read(content_length).to_s
+        buffer = +""
+        while buffer.bytesize < content_length
+          bytes_to_read = [ content_length - buffer.bytesize, 16_384 ].min
+          chunk = read_http_chunk(socket, bytes_to_read)
+          raise RequestTimeoutError, "Connection closed before request body was fully received" if chunk.nil? || chunk.empty?
+
+          buffer << chunk
+        end
+
+        buffer
       end
       private_class_method :read_http_body
+
+      def self.read_http_line(socket)
+        wait_for_socket_data do
+          socket.gets("\r\n")
+        end
+      end
+      private_class_method :read_http_line
+
+      def self.read_http_chunk(socket, bytes_to_read)
+        wait_for_socket_data do
+          socket.read(bytes_to_read)
+        end
+      end
+      private_class_method :read_http_chunk
+
+      def self.wait_for_socket_data
+        Timeout.timeout(SOCKET_READ_TIMEOUT_SECONDS, RequestTimeoutError) do
+          yield
+        end
+      rescue RequestTimeoutError
+        raise RequestTimeoutError, "Timed out waiting for request data"
+      end
+      private_class_method :wait_for_socket_data
 
       def self.rack_env(method:, path:, query:, headers:, body:, host:, port:, server_protocol:, remote_addr:)
         env = {

--- a/lib/gem_docs/mcp/tools.rb
+++ b/lib/gem_docs/mcp/tools.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+    module Tools
+      module_function
+    end
+  end
+end
+
+require "gem_docs/mcp/tools/classes"
+require "gem_docs/mcp/tools/list"
+require "gem_docs/mcp/tools/lookup"
+require "gem_docs/mcp/tools/search"
+require "gem_docs/mcp/tools/summary"
+
+module GemDocs
+  module MCP
+    module Tools
+      def self.all
+        [ List, Summary, Classes, Lookup, Search ]
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp/tools/classes.rb
+++ b/lib/gem_docs/mcp/tools/classes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+    module Tools
+      class Classes < GemDocs::MCP::CommandTool
+        tool_name "classes"
+        description "List documented classes and modules as the CLI JSON payload"
+        command GemDocs::Commands::Classes
+
+        arguments do
+          required(:gem_name).filled(:string).description("Gem name to inspect")
+          optional(:version).filled(:string).description("Optional gem version")
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp/tools/list.rb
+++ b/lib/gem_docs/mcp/tools/list.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+    module Tools
+      class List < GemDocs::MCP::CommandTool
+        tool_name "list"
+        description "List installed gems as the CLI JSON payload"
+        command GemDocs::Commands::List
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp/tools/lookup.rb
+++ b/lib/gem_docs/mcp/tools/lookup.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+    module Tools
+      class Lookup < GemDocs::MCP::CommandTool
+        tool_name "lookup"
+        description "Look up a constant or method as the CLI JSON payload"
+        command GemDocs::Commands::Lookup
+
+        arguments do
+          required(:path).filled(:string).description("Constant or method path to resolve")
+          optional(:gem).filled(:string).description("Optional gem name to scope the lookup")
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp/tools/search.rb
+++ b/lib/gem_docs/mcp/tools/search.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+    module Tools
+      class Search < GemDocs::MCP::CommandTool
+        tool_name "search"
+        description "Search gem documentation as the CLI JSON payload"
+        command GemDocs::Commands::Search
+
+        arguments do
+          required(:query).filled(:string).description("Query to search for")
+          optional(:gem).filled(:string).description("Optional gem name to search within")
+          optional(:scope).filled(:string).description("Search scope: methods, classes, or all")
+          optional(:limit).filled(:integer).description("Maximum number of results")
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/mcp/tools/summary.rb
+++ b/lib/gem_docs/mcp/tools/summary.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module MCP
+    module Tools
+      class Summary < GemDocs::MCP::CommandTool
+        tool_name "summary"
+        description "Summarize a gem as the CLI JSON payload"
+        command GemDocs::Commands::Summary
+
+        arguments do
+          required(:gem_name).filled(:string).description("Gem name to summarize")
+          optional(:version).filled(:string).description("Optional gem version")
+        end
+      end
+    end
+  end
+end

--- a/sig/deps/dry_cli.rbs
+++ b/sig/deps/dry_cli.rbs
@@ -17,7 +17,7 @@ module Dry
     def self.desc: (String description) -> void
     def self.example: (Array[String] examples) -> void
     def self.argument: (Symbol name, type: Symbol) -> void
-    def self.option: (Symbol name, ?values: Array[String]?, ?default: String?, desc: String) -> void
+    def self.option: (Symbol name, ?values: Array[String]?, ?default: untyped, ?type: Symbol?, desc: String) -> void
     def self.description: -> String?
     def self.examples: -> Array[String]
 

--- a/sig/deps/fast_mcp.rbs
+++ b/sig/deps/fast_mcp.rbs
@@ -1,0 +1,27 @@
+module FastMcp
+  class Tool
+    attr_accessor self.server: FastMcp::Server?
+
+    def self.arguments: { () -> void } -> void
+    def self.required: (Symbol name) -> untyped
+    def self.optional: (Symbol name) -> untyped
+    def self.tool_name: (?String name) -> String?
+    def self.description: (?String description) -> String?
+    def self.input_schema: -> untyped
+    def self.input_schema_to_json: -> untyped
+
+    def initialize: (?headers: Hash[untyped, untyped]) -> void
+    def call: (**untyped kwargs) -> untyped
+  end
+
+  class Server
+    attr_accessor transport: untyped
+    attr_reader tools: Hash[String, singleton(FastMcp::Tool)]
+
+    def initialize: (name: String, version: String, ?logger: untyped, ?capabilities: Hash[untyped, untyped]) -> void
+    def register_tools: (*singleton(FastMcp::Tool) tools) -> void
+    def start: -> void
+    def start_rack: (untyped app, ?Hash[Symbol, untyped] options) -> untyped
+    def handle_json_request: (String | Hash[untyped, untyped] request, ?headers: Hash[untyped, untyped]) -> String?
+  end
+end

--- a/sig/deps/mcp_stdlib.rbs
+++ b/sig/deps/mcp_stdlib.rbs
@@ -12,3 +12,7 @@ class TCPServer
   def self.open: (String host, Integer port) { (TCPServer server) -> untyped } -> untyped
   def accept: -> untyped
 end
+
+module Timeout
+  def self.timeout: [T] (Integer seconds, singleton(StandardError) klass) { () -> T } -> T
+end

--- a/sig/deps/mcp_stdlib.rbs
+++ b/sig/deps/mcp_stdlib.rbs
@@ -1,0 +1,14 @@
+class OptionParser
+  def self.new: { (OptionParser parser) -> void } -> OptionParser
+  def initialize: { (OptionParser parser) -> void } -> void
+  def on: (*untyped args) { (*untyped) -> void } -> void
+  def parse!: (Array[String] arguments) -> Array[String]
+
+  class ParseError < StandardError
+  end
+end
+
+class TCPServer
+  def self.open: (String host, Integer port) { (TCPServer server) -> untyped } -> untyped
+  def accept: -> untyped
+end

--- a/sig/deps/mcp_stdlib.rbs
+++ b/sig/deps/mcp_stdlib.rbs
@@ -13,6 +13,9 @@ class TCPServer
   def accept: -> untyped
 end
 
+class SocketError < StandardError
+end
+
 module Timeout
   def self.timeout: [T] (Integer seconds, singleton(StandardError) klass) { () -> T } -> T
 end

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -366,8 +366,12 @@ module GemDocs
     end
 
     class Server
+      class RequestTooLargeError < StandardError
+      end
+
       DEFAULT_MODE: String
       DEFAULT_PORT: Integer
+      MAX_REQUEST_BODY_BYTES: Integer
       HTTP_STATUS_REASONS: Hash[Integer, String]
 
       def self.start: (?Array[String] arguments, ?out: untyped, ?err: untyped) -> Integer
@@ -396,6 +400,7 @@ module GemDocs
       def self.write_http_response: (untyped socket, Integer status, Hash[untyped, untyped] headers, untyped body) -> void
       def self.http_status_reason: (Integer status) -> String
       def self.not_found_response: -> [Integer, Hash[String, String], Array[String]]
+      def self.json_headers: -> Hash[String, String]
     end
   end
 end

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -369,9 +369,13 @@ module GemDocs
       class RequestTooLargeError < StandardError
       end
 
+      class RequestTimeoutError < StandardError
+      end
+
       DEFAULT_MODE: String
       DEFAULT_PORT: Integer
       MAX_REQUEST_BODY_BYTES: Integer
+      SOCKET_READ_TIMEOUT_SECONDS: Integer
       HTTP_STATUS_REASONS: Hash[Integer, String]
 
       def self.start: (?Array[String] arguments, ?out: untyped, ?err: untyped) -> Integer
@@ -386,6 +390,9 @@ module GemDocs
       def self.handle_http_connection: (untyped socket, untyped app, host: String, port: Integer) -> void
       def self.read_http_headers: (untyped socket) -> Hash[String, String]
       def self.read_http_body: (untyped socket, Hash[String, String] headers) -> String
+      def self.read_http_line: (untyped socket) -> String?
+      def self.read_http_chunk: (untyped socket, Integer bytes_to_read) -> String?
+      def self.wait_for_socket_data: { () -> untyped } -> untyped
       def self.rack_env: (
         method: String,
         path: String,

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -385,8 +385,8 @@ module GemDocs
       private
 
       def self.parse_options: (Array[String] arguments, err: untyped) -> Hash[Symbol, untyped]?
-      def self.run_http: (FastMcp::Server server, host: String, port: Integer, out: untyped) -> Integer
-      def self.serve_http: (untyped app, host: String, port: Integer) -> void
+      def self.run_http: (FastMcp::Server server, host: String, port: Integer, out: untyped, err: untyped) -> Integer
+      def self.serve_http: (untyped app, host: String, port: Integer, out: untyped) -> void
       def self.handle_http_connection: (untyped socket, untyped app, host: String, port: Integer) -> void
       def self.read_http_headers: (untyped socket) -> Hash[String, String]
       def self.read_http_body: (untyped socket, Hash[String, String] headers) -> String
@@ -407,7 +407,7 @@ module GemDocs
       def self.remote_addr_for: (untyped socket) -> String
       def self.write_http_response: (untyped socket, Integer status, Hash[untyped, untyped] headers, untyped body) -> void
       def self.http_status_reason: (Integer status) -> String
-      def self.not_found_response: -> [Integer, Hash[String, String], Array[String]]
+      def self.not_found_response: (String path) -> [Integer, Hash[String, String], Array[String]]
       def self.json_headers: -> Hash[String, String]
     end
   end

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -404,6 +404,7 @@ module GemDocs
         server_protocol: String,
         remote_addr: String
       ) -> Hash[String, untyped]
+      def self.remote_addr_for: (untyped socket) -> String
       def self.write_http_response: (untyped socket, Integer status, Hash[untyped, untyped] headers, untyped body) -> void
       def self.http_status_reason: (Integer status) -> String
       def self.not_found_response: -> [Integer, Hash[String, String], Array[String]]

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -336,9 +336,66 @@ module GemDocs
   end
 
   module MCP
+    class CommandTool < FastMcp::Tool
+      def self.command: (?untyped command_class) -> untyped
+      def call: (**untyped kwargs) -> Hash[Symbol, untyped]
+
+      private
+
+      def command_arguments: (**untyped kwargs) -> Hash[Symbol, untyped]
+      def execute_command: (**untyped kwargs) -> Hash[Symbol, untyped]
+    end
+
+    module Tools
+      def self.all: -> Array[untyped]
+
+      class Classes < GemDocs::MCP::CommandTool
+      end
+
+      class List < GemDocs::MCP::CommandTool
+      end
+
+      class Lookup < GemDocs::MCP::CommandTool
+      end
+
+      class Search < GemDocs::MCP::CommandTool
+      end
+
+      class Summary < GemDocs::MCP::CommandTool
+      end
+    end
+
     class Server
+      DEFAULT_MODE: String
+      DEFAULT_PORT: Integer
+      HTTP_STATUS_REASONS: Hash[Integer, String]
+
       def self.start: (?Array[String] arguments, ?out: untyped, ?err: untyped) -> Integer
+      def self.build_fast_mcp_server: -> FastMcp::Server
       def self.load_fast_mcp: (untyped err) -> bool
+
+      private
+
+      def self.parse_options: (Array[String] arguments, err: untyped) -> Hash[Symbol, untyped]?
+      def self.run_http: (FastMcp::Server server, host: String, port: Integer, out: untyped) -> Integer
+      def self.serve_http: (untyped app, host: String, port: Integer) -> void
+      def self.handle_http_connection: (untyped socket, untyped app, host: String, port: Integer) -> void
+      def self.read_http_headers: (untyped socket) -> Hash[String, String]
+      def self.read_http_body: (untyped socket, Hash[String, String] headers) -> String
+      def self.rack_env: (
+        method: String,
+        path: String,
+        query: String,
+        headers: Hash[String, String],
+        body: String,
+        host: String,
+        port: Integer,
+        server_protocol: String,
+        remote_addr: String
+      ) -> Hash[String, untyped]
+      def self.write_http_response: (untyped socket, Integer status, Hash[untyped, untyped] headers, untyped body) -> void
+      def self.http_status_reason: (Integer status) -> String
+      def self.not_found_response: -> [Integer, Hash[String, String], Array[String]]
     end
   end
 end
@@ -445,6 +502,10 @@ module GemDocs::Commands
   end
 
   class Server < Base
-    def call: (?args: Array[String], **untyped) -> Integer
+    def call: (?mode: String, ?port: String, ?bind_all: bool, **untyped) -> Integer
+
+    private
+
+    def server_arguments: (mode: String, port: String, bind_all: bool) -> Array[String]
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -98,6 +98,23 @@ RSpec.describe GemDocs::CLI do
     expect(stdout.string).to eq("searched rack\n")
   end
 
+  it "passes server mode options through to the MCP server entrypoint" do
+    allow(GemDocs::MCP::Server).to receive(:start).and_return(0)
+
+    status = described_class.start(
+      [ "server", "--mode", "http", "--port", "7001", "--bind-all" ],
+      out: stdout,
+      err: stderr
+    )
+
+    expect(status).to eq(0)
+    expect(GemDocs::MCP::Server).to have_received(:start).with(
+      [ "--mode", "http", "--port", "7001", "--bind-all" ],
+      out: stdout,
+      err: stderr
+    )
+  end
+
   it "renders structured JSON for handled command errors" do
     stub_const("GemDocs::Commands::List", Class.new(GemDocs::Commands::Base) do
       desc "Show installed gems"

--- a/spec/executables_load_spec.rb
+++ b/spec/executables_load_spec.rb
@@ -17,19 +17,20 @@ RSpec.describe "executables" do
     expect("#{stdout}\n#{stderr}").to include("gem-docs")
   end
 
-  it "loads the server executable and reports the optional fast-mcp dependency cleanly" do
+  it "loads the server executable without emitting placeholder output" do
     stdout, stderr, status = run_command("ruby", "-Ilib", "exe/gem-docs-server")
 
     expect(status).to be_success
-    expect("#{stdout}\n#{stderr}").to include("gem-docs-server")
+    expect(stdout).to eq("")
+    expect(stderr).to eq("")
   end
 
-  it "routes the CLI server command through the MCP server loader" do
+  it "routes the CLI server command through the MCP server loader without extra output" do
     stdout, stderr, status = run_command("ruby", "-Ilib", "exe/gem-docs", "server")
 
     expect(status).to be_success
     expect(stderr).to eq("")
-    expect(stdout).to include("gem-docs-server placeholder loaded")
+    expect(stdout).to eq("")
   end
 
   it "reports fast-mcp load failures from the CLI server command without a stack trace" do

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::MCP::Server do
+  class CapturingTransport
+    attr_reader :messages
+
+    def initialize
+      @messages = []
+    end
+
+    def send_message(message)
+      @messages << message
+    end
+  end
+
+  describe ".build_fast_mcp_server" do
+    it "registers the supported gem-docs MCP tools" do
+      server = described_class.build_fast_mcp_server
+
+      expect(server.tools.keys).to contain_exactly("list", "summary", "classes", "lookup", "search")
+    end
+
+    it "delegates tool calls to the shared CLI command layer" do
+      stub_const("GemDocs::Commands::List", Class.new(GemDocs::Commands::Base) do
+        def call(format: "text", **)
+          out.puts(%([{\"name\":\"rack\",\"version\":\"3.2.6\",\"doc_source\":\"yard\"}]))
+          format == "json" ? 0 : 1
+        end
+      end)
+      GemDocs::MCP::Tools::List.command(GemDocs::Commands::List) if defined?(GemDocs::MCP::Tools::List)
+
+      server = described_class.build_fast_mcp_server
+      transport = CapturingTransport.new
+      server.transport = transport
+
+      server.handle_json_request(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list",
+            arguments: {}
+          }
+        }
+      )
+      response = transport.messages.last
+
+      expect(response.dig(:result, :isError)).to be(false)
+      expect(response.dig(:result, :content, 0, :text)).to eq("[{\"name\":\"rack\",\"version\":\"3.2.6\",\"doc_source\":\"yard\"}]\n")
+    end
+
+    it "returns the shared CLI JSON error envelope when a delegated command fails" do
+      stub_const("GemDocs::Commands::Summary", Class.new(GemDocs::Commands::Base) do
+        def call(**)
+          raise GemDocs::GemNotFound.new("missing-gem")
+        end
+      end)
+      GemDocs::MCP::Tools::Summary.command(GemDocs::Commands::Summary) if defined?(GemDocs::MCP::Tools::Summary)
+
+      server = described_class.build_fast_mcp_server
+      transport = CapturingTransport.new
+      server.transport = transport
+
+      server.handle_json_request(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "summary",
+            arguments: {
+              gem_name: "missing-gem"
+            }
+          }
+        }
+      )
+      response = transport.messages.last
+
+      expect(response.dig(:result, :isError)).to be(true)
+      expect(JSON.parse(response.dig(:result, :content, 0, :text))).to eq(
+        "error" => "not_found",
+        "message" => "Gem 'missing-gem' is not installed"
+      )
+    end
+
+    it "publishes MCP input schemas for the supported tool arguments" do
+      server = described_class.build_fast_mcp_server
+      transport = CapturingTransport.new
+      server.transport = transport
+
+      server.handle_json_request(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list"
+        }
+      )
+      response = transport.messages.last
+      summary_tool = response.dig(:result, :tools).find { |tool| tool[:name] == "summary" }
+      search_tool = response.dig(:result, :tools).find { |tool| tool[:name] == "search" }
+
+      expect(summary_tool.dig(:inputSchema, :required)).to eq([ "gem_name" ])
+      expect(summary_tool.dig(:inputSchema, :properties, :version, :type)).to eq("string")
+      expect(search_tool.dig(:inputSchema, :properties, :limit, :type)).to eq("integer")
+    end
+  end
+
+  describe ".start" do
+    let(:fast_mcp_server) { instance_double(FastMcp::Server, start: nil) }
+
+    before do
+      allow(described_class).to receive(:load_fast_mcp).and_return(true)
+      allow(described_class).to receive(:build_fast_mcp_server).and_return(fast_mcp_server)
+    end
+
+    it "starts the FastMcp server in stdio mode by default" do
+      status = described_class.start([], err: StringIO.new)
+
+      expect(status).to eq(0)
+      expect(fast_mcp_server).to have_received(:start)
+    end
+
+    it "routes http mode through the HTTP server runner" do
+      allow(described_class).to receive(:run_http).and_return(0)
+
+      status = described_class.start([ "--mode", "http", "--port", "7001", "--bind-all" ], err: StringIO.new)
+
+      expect(status).to eq(0)
+      expect(described_class).to have_received(:run_http).with(
+        fast_mcp_server,
+        host: "0.0.0.0",
+        port: 7001,
+        out: anything
+      )
+    end
+  end
+end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -55,6 +55,38 @@ RSpec.describe GemDocs::MCP::Server do
       expect(response.dig(:result, :content, 0, :text)).to eq("[{\"name\":\"rack\",\"version\":\"3.2.6\",\"doc_source\":\"yard\"}]\n")
     end
 
+    it "forces delegated tool calls to use JSON formatting" do
+      stub_const("GemDocs::Commands::List", Class.new(GemDocs::Commands::Base) do
+        def call(format: "text", **)
+          out.puts(format)
+          0
+        end
+      end)
+      GemDocs::MCP::Tools::List.command(GemDocs::Commands::List) if defined?(GemDocs::MCP::Tools::List)
+
+      server = described_class.build_fast_mcp_server
+      transport = CapturingTransport.new
+      server.transport = transport
+
+      server.handle_json_request(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "list",
+            arguments: {
+              format: "text"
+            }
+          }
+        }
+      )
+      response = transport.messages.last
+
+      expect(response.dig(:result, :isError)).to be(false)
+      expect(response.dig(:result, :content, 0, :text)).to eq("json\n")
+    end
+
     it "returns the shared CLI JSON error envelope when a delegated command fails" do
       stub_const("GemDocs::Commands::Summary", Class.new(GemDocs::Commands::Base) do
         def call(**)
@@ -170,7 +202,8 @@ RSpec.describe GemDocs::MCP::Server do
         fast_mcp_server,
         host: "0.0.0.0",
         port: 7001,
-        out: anything
+        out: anything,
+        err: anything
       )
     end
   end
@@ -222,6 +255,52 @@ RSpec.describe GemDocs::MCP::Server do
       expect(written_response).to include("413 Payload Too Large")
     end
 
+    it "normalizes request header names before reading the body and building rack env" do
+      socket = double("Socket")
+      written_response = +""
+      received_env = nil
+
+      allow(socket).to receive(:gets).with("\r\n").and_return(
+        "POST /mcp/messages HTTP/1.1\r\n",
+        "content-length: 7\r\n",
+        "content-type: application/json\r\n",
+        "\r\n"
+      )
+      allow(socket).to receive(:read).with(7).and_return("{\"a\":1}")
+      allow(described_class).to receive(:wait_for_socket_data).and_yield
+      allow(socket).to receive(:peeraddr).with(false).and_return([ nil, nil, nil, "127.0.0.1" ])
+      allow(socket).to receive(:write) do |chunk|
+        written_response << chunk
+      end
+
+      described_class.send(
+        :handle_http_connection,
+        socket,
+        lambda do |env|
+          received_env = env
+          [ 200, { "Content-Type" => "application/json" }, [ "{\"ok\":true}" ] ]
+        end,
+        host: "127.0.0.1",
+        port: 6040
+      )
+
+      expect(received_env.fetch("CONTENT_LENGTH")).to eq("7")
+      expect(received_env.fetch("CONTENT_TYPE")).to eq("application/json")
+      expect(received_env.fetch("rack.input").read).to eq("{\"a\":1}")
+      expect(written_response).to include("200 OK")
+    end
+
+    it "returns a structured not found payload" do
+      status, headers, body = described_class.send(:not_found_response, "/missing")
+
+      expect(status).to eq(404)
+      expect(headers).to eq("Content-Type" => "application/json")
+      expect(JSON.parse(body.fetch(0))).to eq(
+        "error" => "not_found",
+        "message" => "No MCP endpoint matches /missing"
+      )
+    end
+
     it "keeps the HTTP accept loop running when a request crashes" do
       listener = instance_double("TCPServer")
       socket = instance_double("Socket", closed?: false)
@@ -241,8 +320,25 @@ RSpec.describe GemDocs::MCP::Server do
       allow(socket).to receive(:close)
 
       expect do
-        described_class.send(:serve_http, :app, host: "127.0.0.1", port: 6040)
+        described_class.send(:serve_http, :app, host: "127.0.0.1", port: 6040, out: StringIO.new)
       end.to raise_error(Interrupt)
+    end
+  end
+
+  describe ".run_http" do
+    it "returns a non-zero status when the HTTP listener cannot bind" do
+      fast_mcp_server = instance_double(FastMcp::Server, start_rack: :app)
+      out = StringIO.new
+      err = StringIO.new
+
+      allow(described_class).to receive(:serve_http)
+        .with(:app, host: "127.0.0.1", port: 6040, out: out)
+        .and_raise(Errno::EADDRINUSE, "Address already in use")
+
+      status = described_class.send(:run_http, fast_mcp_server, host: "127.0.0.1", port: 6040, out: out, err: err)
+
+      expect(status).to eq(1)
+      expect(err.string).to include("gem-docs MCP HTTP server failed to bind 127.0.0.1:6040")
     end
   end
 end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -142,6 +142,27 @@ RSpec.describe GemDocs::MCP::Server do
   end
 
   describe "HTTP request handling" do
+    it "returns 408 when the client stops sending request data" do
+      socket = instance_double("Socket")
+      written_response = +""
+
+      allow(described_class).to receive(:wait_for_socket_data)
+        .and_raise(described_class::RequestTimeoutError, "timed out waiting for request data")
+      allow(socket).to receive(:write) do |chunk|
+        written_response << chunk
+      end
+
+      described_class.send(
+        :handle_http_connection,
+        socket,
+        ->(_env) { raise "should not reach app" },
+        host: "127.0.0.1",
+        port: 6040
+      )
+
+      expect(written_response).to include("408 Request Timeout")
+    end
+
     it "returns 413 for request bodies above the configured size limit" do
       socket = instance_double("Socket")
       written_response = +""
@@ -151,6 +172,7 @@ RSpec.describe GemDocs::MCP::Server do
         "Content-Length: #{(10 * 1024 * 1024) + 1}\r\n",
         "\r\n"
       )
+      allow(described_class).to receive(:wait_for_socket_data).and_yield
       allow(socket).to receive(:write) do |chunk|
         written_response << chunk
       end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -140,4 +140,53 @@ RSpec.describe GemDocs::MCP::Server do
       )
     end
   end
+
+  describe "HTTP request handling" do
+    it "returns 413 for request bodies above the configured size limit" do
+      socket = instance_double("Socket")
+      written_response = +""
+
+      allow(socket).to receive(:gets).with("\r\n").and_return(
+        "POST /mcp/messages HTTP/1.1\r\n",
+        "Content-Length: #{(10 * 1024 * 1024) + 1}\r\n",
+        "\r\n"
+      )
+      allow(socket).to receive(:write) do |chunk|
+        written_response << chunk
+      end
+
+      described_class.send(
+        :handle_http_connection,
+        socket,
+        ->(_env) { raise "should not reach app" },
+        host: "127.0.0.1",
+        port: 6040
+      )
+
+      expect(written_response).to include("413 Payload Too Large")
+    end
+
+    it "keeps the HTTP accept loop running when a request crashes" do
+      listener = instance_double("TCPServer")
+      socket = instance_double("Socket", closed?: false)
+
+      accept_calls = 0
+      allow(TCPServer).to receive(:open).with("127.0.0.1", 6040).and_yield(listener)
+      allow(listener).to receive(:accept) do
+        accept_calls += 1
+        raise Interrupt if accept_calls > 1
+
+        socket
+      end
+      allow(described_class).to receive(:warn)
+      allow(described_class).to receive(:handle_http_connection)
+        .with(socket, :app, host: "127.0.0.1", port: 6040)
+        .and_raise(StandardError, "boom")
+      allow(socket).to receive(:close)
+
+      expect do
+        described_class.send(:serve_http, :app, host: "127.0.0.1", port: 6040)
+      end.to raise_error(Interrupt)
+    end
+  end
 end

--- a/spec/mcp/server_spec.rb
+++ b/spec/mcp/server_spec.rb
@@ -89,6 +89,40 @@ RSpec.describe GemDocs::MCP::Server do
       )
     end
 
+    it "converts unexpected command exceptions into an MCP error result" do
+      stub_const("GemDocs::Commands::Lookup", Class.new(GemDocs::Commands::Base) do
+        def call(**)
+          raise ArgumentError, "boom"
+        end
+      end)
+      GemDocs::MCP::Tools::Lookup.command(GemDocs::Commands::Lookup) if defined?(GemDocs::MCP::Tools::Lookup)
+
+      server = described_class.build_fast_mcp_server
+      transport = CapturingTransport.new
+      server.transport = transport
+
+      server.handle_json_request(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "lookup",
+            arguments: {
+              path: "Widget"
+            }
+          }
+        }
+      )
+      response = transport.messages.last
+
+      expect(response.dig(:result, :isError)).to be(true)
+      expect(JSON.parse(response.dig(:result, :content, 0, :text))).to eq(
+        "error" => "internal_error",
+        "message" => "boom"
+      )
+    end
+
     it "publishes MCP input schemas for the supported tool arguments" do
       server = described_class.build_fast_mcp_server
       transport = CapturingTransport.new


### PR DESCRIPTION
## Summary
- implement the optional gem-docs server MCP wrapper with stdio and HTTP modes
- expose list, summary, classes, lookup, and search through FastMcp tools that delegate to the existing CLI command layer
- add tests, type signatures, and README usage for the MCP server path

Closes #12

## Test plan
- bundle exec rubocop -a
- bundle exec rspec
- bundle exec steep check