### PR TITLE
feat: add persistent artifact cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 CLI-first gem documentation lookup for local Ruby projects, with an optional MCP server wrapper.
 
+## Persistent cache
+
+`gem-docs` stores normalized documentation artifacts in a local SQLite database at `.gem-docs/cache.sqlite3`.
+The cache keeps source-derived artifacts and future compressed artifacts in separate rows keyed by gem name, gem version, and lookup target.
+Entries are invalidated automatically when the gem contents change or when the cache schema/artifact version changes.
+
 ## CLI
 
 ```bash

--- a/gem-docs.gemspec
+++ b/gem-docs.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "dry-cli", "~> 1.0"
   spec.add_dependency "prism", "~> 1.4"
+  spec.add_dependency "sqlite3", "~> 1.7"
   spec.add_dependency "yard", "~> 0.9"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/lib/gem_docs/artifact_cache.rb
+++ b/lib/gem_docs/artifact_cache.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "sqlite3"
+
+module GemDocs
+  class ArtifactCache
+    SCHEMA_VERSION = 1
+    GEM_LOOKUP_TARGET = "__gem__"
+    ARTIFACT_VERSIONS = {
+      source: 1,
+      compressed: 1
+    }.freeze
+
+    def self.default(root: Dir.pwd)
+      new(path: File.join(root, ".gem-docs", "cache.sqlite3"))
+    end
+
+    def initialize(path:)
+      @path = path
+    end
+
+    def fetch_loaded_gem(gem_name:, gem_version:, invalidation_key:)
+      payload = fetch_artifact(
+        gem_name: gem_name,
+        gem_version: gem_version,
+        lookup_target: GEM_LOOKUP_TARGET,
+        artifact_kind: :source,
+        invalidation_key: invalidation_key
+      )
+      return unless payload
+
+      build_loaded_gem(payload)
+    end
+
+    def write_loaded_gem(loaded_gem, invalidation_key:)
+      write_artifact(
+        gem_name: loaded_gem.name,
+        gem_version: loaded_gem.version,
+        lookup_target: GEM_LOOKUP_TARGET,
+        artifact_kind: :source,
+        payload: serialize_loaded_gem(loaded_gem),
+        invalidation_key: invalidation_key
+      )
+    end
+
+    def fetch_artifact(gem_name:, gem_version:, lookup_target:, artifact_kind:, invalidation_key:, artifact_version: nil)
+      with_database do |database|
+        row = database.get_first_row(
+          <<~SQL,
+            SELECT payload
+            FROM documentation_artifacts
+            WHERE gem_name = ?
+              AND gem_version = ?
+              AND lookup_target = ?
+              AND artifact_kind = ?
+              AND invalidation_key = ?
+              AND artifact_version = ?
+          SQL
+          gem_name,
+          gem_version,
+          lookup_target,
+          artifact_kind.to_s,
+          invalidation_key,
+          artifact_version || default_artifact_version(artifact_kind)
+        )
+
+        row ? JSON.parse(row[0]) : nil
+      end
+    end
+
+    def fetch_with_fallback(gem_name:, gem_version:, lookup_target:, invalidation_key:)
+      compressed = fetch_artifact(
+        gem_name: gem_name,
+        gem_version: gem_version,
+        lookup_target: lookup_target,
+        artifact_kind: :compressed,
+        invalidation_key: invalidation_key
+      )
+      return { kind: :compressed, payload: compressed } if compressed
+
+      source = fetch_artifact(
+        gem_name: gem_name,
+        gem_version: gem_version,
+        lookup_target: lookup_target,
+        artifact_kind: :source,
+        invalidation_key: invalidation_key
+      )
+      return { kind: :source, payload: source } if source
+
+      nil
+    end
+
+    def write_artifact(gem_name:, gem_version:, lookup_target:, artifact_kind:, payload:, invalidation_key:, artifact_version: nil)
+      with_database do |database|
+        database.execute(
+          <<~SQL,
+            INSERT INTO documentation_artifacts (
+              gem_name,
+              gem_version,
+              lookup_target,
+              artifact_kind,
+              invalidation_key,
+              artifact_version,
+              payload,
+              updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(gem_name, gem_version, lookup_target, artifact_kind)
+            DO UPDATE SET
+              invalidation_key = excluded.invalidation_key,
+              artifact_version = excluded.artifact_version,
+              payload = excluded.payload,
+              updated_at = CURRENT_TIMESTAMP
+          SQL
+          gem_name,
+          gem_version,
+          lookup_target,
+          artifact_kind.to_s,
+          invalidation_key,
+          artifact_version || default_artifact_version(artifact_kind),
+          JSON.generate(payload)
+        )
+      end
+
+      true
+    end
+
+    private
+
+    attr_reader :path
+
+    def with_database
+      FileUtils.mkdir_p(File.dirname(path))
+      database = SQLite3::Database.new(path)
+      ensure_schema!(database)
+      yield database
+    ensure
+      database&.close
+    end
+
+    def ensure_schema!(database)
+      database.execute_batch(<<~SQL)
+        CREATE TABLE IF NOT EXISTS cache_metadata (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+      SQL
+
+      schema_version = database.get_first_row(
+        "SELECT value FROM cache_metadata WHERE key = ?",
+        "schema_version"
+      )&.first
+
+      if schema_version.to_i != SCHEMA_VERSION
+        database.execute_batch(<<~SQL)
+          DROP TABLE IF EXISTS documentation_artifacts;
+          DELETE FROM cache_metadata;
+        SQL
+
+        database.execute(
+          "INSERT INTO cache_metadata (key, value) VALUES (?, ?)",
+          "schema_version",
+          SCHEMA_VERSION.to_s
+        )
+      end
+
+      database.execute_batch(<<~SQL)
+        CREATE TABLE IF NOT EXISTS documentation_artifacts (
+          gem_name TEXT NOT NULL,
+          gem_version TEXT NOT NULL,
+          lookup_target TEXT NOT NULL,
+          artifact_kind TEXT NOT NULL,
+          invalidation_key TEXT NOT NULL,
+          artifact_version INTEGER NOT NULL,
+          payload TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          PRIMARY KEY (gem_name, gem_version, lookup_target, artifact_kind)
+        );
+      SQL
+    end
+
+    def serialize_loaded_gem(loaded_gem)
+      {
+        "name" => loaded_gem.name,
+        "version" => loaded_gem.version,
+        "summary" => loaded_gem.summary,
+        "description" => loaded_gem.description,
+        "homepage" => loaded_gem.homepage,
+        "license" => loaded_gem.license,
+        "path" => loaded_gem.path,
+        "doc_source" => loaded_gem.doc_source.to_s,
+        "entry_points" => loaded_gem.entry_points,
+        "objects" => loaded_gem.objects.map { |object| serialize_entry(object) }
+      }
+    end
+
+    def serialize_entry(entry)
+      {
+        "path" => entry.path,
+        "name" => entry.name,
+        "kind" => entry.kind.to_s,
+        "visibility" => entry.visibility.to_s,
+        "docstring" => entry.docstring,
+        "signature" => entry.signature,
+        "source_location" => entry.source_location,
+        "superclass" => entry.superclass,
+        "doc_source" => entry.doc_source.to_s,
+        "tags" => entry.tags,
+        "aliases" => entry.aliases
+      }
+    end
+
+    def build_loaded_gem(payload)
+      GemDocs::DocRegistry::LoadedGem.new(
+        name: payload.fetch("name"),
+        version: payload.fetch("version"),
+        summary: payload["summary"],
+        description: payload["description"],
+        homepage: payload["homepage"],
+        license: payload["license"],
+        path: payload.fetch("path"),
+        doc_source: payload.fetch("doc_source").to_sym,
+        objects: Array(payload["objects"]).map { |entry| build_entry(entry) },
+        entry_points: Array(payload["entry_points"])
+      )
+    end
+
+    def build_entry(payload)
+      GemDocs::DocRegistry::Entry.new(
+        path: payload.fetch("path"),
+        name: payload.fetch("name"),
+        kind: payload.fetch("kind").to_sym,
+        visibility: payload.fetch("visibility").to_sym,
+        docstring: payload.fetch("docstring"),
+        signature: payload.fetch("signature"),
+        source_location: payload["source_location"],
+        superclass: payload["superclass"],
+        doc_source: payload.fetch("doc_source").to_sym,
+        tags: symbolize_hash(payload["tags"] || {}),
+        aliases: Array(payload["aliases"])
+      )
+    end
+
+    def symbolize_hash(value)
+      case value
+      when Hash
+        value.each_with_object(Hash.new) do |(key, nested_value), hash|
+          hash[key.to_sym] = symbolize_hash(nested_value)
+        end
+      when Array
+        value.map { |item| symbolize_hash(item) }
+      else
+        value
+      end
+    end
+
+    def default_artifact_version(artifact_kind)
+      ARTIFACT_VERSIONS.fetch(artifact_kind.to_sym)
+    end
+  end
+end

--- a/lib/gem_docs/artifact_cache.rb
+++ b/lib/gem_docs/artifact_cache.rb
@@ -7,6 +7,9 @@ require "sqlite3"
 module GemDocs
   class ArtifactCache
     SCHEMA_VERSION = 1
+    BUSY_TIMEOUT_MS = 5_000
+    MAX_BUSY_RETRIES = 2
+    BUSY_RETRY_DELAY = 0.05
     GEM_LOOKUP_TARGET = "__gem__"
     ARTIFACT_VERSIONS = {
       source: 1,
@@ -130,11 +133,18 @@ module GemDocs
 
     attr_reader :path
 
-    def with_database
+    def with_database(attempt = 0)
       FileUtils.mkdir_p(File.dirname(path))
+      database = nil
       database = SQLite3::Database.new(path)
+      database.busy_timeout = BUSY_TIMEOUT_MS
       ensure_schema!(database)
       yield database
+    rescue SQLite3::BusyException, SQLite3::LockedException
+      raise if attempt >= MAX_BUSY_RETRIES
+
+      sleep(BUSY_RETRY_DELAY * (attempt + 1))
+      with_database(attempt + 1) { |retry_database| yield retry_database }
     ensure
       database&.close
     end

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -3,6 +3,7 @@
 require "open3"
 require "prism"
 require "yard"
+require "digest"
 
 module GemDocs
   class DocRegistry
@@ -120,10 +121,11 @@ module GemDocs
       end
     end
 
-    def initialize(shell_runner: nil)
+    def initialize(shell_runner: nil, cache: nil)
       @loaded_gems = {}
       @doc_sources = {}
       @shell_runner = shell_runner || method(:run_command)
+      @cache = cache.nil? ? GemDocs::ArtifactCache.default(root: Dir.pwd) : cache
     end
 
     def load_gem(name, version: nil)
@@ -140,8 +142,21 @@ module GemDocs
       end
       raise GemDocs::GemNotFound.new(name) unless spec
 
+      invalidation_key = artifact_invalidation_key(spec)
+      cached_gem = @cache&.fetch_loaded_gem(
+        gem_name: spec.name,
+        gem_version: spec.version.to_s,
+        invalidation_key: invalidation_key
+      )
+      if cached_gem
+        @doc_sources[cache_key] = cached_gem.doc_source
+        @loaded_gems[cache_key] = cached_gem
+        return cached_gem
+      end
+
       loaded_gem = build_loaded_gem(spec)
       @doc_sources[cache_key] = loaded_gem.doc_source
+      @cache&.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
     end
 
@@ -200,6 +215,35 @@ module GemDocs
       return :source_only if source_objects_available?(spec)
 
       :none
+    end
+
+    def artifact_invalidation_key(spec)
+      digest = Digest::SHA256.new
+      digest << "schema:#{GemDocs::ArtifactCache::SCHEMA_VERSION}\n"
+      digest << "gem:#{spec.name}\n"
+      digest << "version:#{spec.version}\n"
+      digest << "path:#{spec.full_gem_path}\n"
+
+      artifact_files_for(spec).sort.each do |file|
+        digest << "file:#{file.delete_prefix("#{spec.full_gem_path}/")}\n"
+        digest << File.binread(file)
+      end
+
+      digest.hexdigest
+    end
+
+    def artifact_files_for(spec)
+      files = ruby_files_for(spec)
+      yardoc = yardoc_path_for(spec)
+      files << yardoc if File.file?(yardoc)
+
+      if File.directory?(spec.doc_dir)
+        files.concat(
+          Dir.glob(File.join(spec.doc_dir, "**", "*")).select { |path| File.file?(path) }
+        )
+      end
+
+      files.uniq
     end
 
     def cache_key_for(name, version)

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -142,12 +142,8 @@ module GemDocs
       end
       raise GemDocs::GemNotFound.new(name) unless spec
 
-      invalidation_key = artifact_invalidation_key(spec)
-      cached_gem = @cache&.fetch_loaded_gem(
-        gem_name: spec.name,
-        gem_version: spec.version.to_s,
-        invalidation_key: invalidation_key
-      )
+      invalidation_key = safe_artifact_invalidation_key(spec)
+      cached_gem = fetch_cached_loaded_gem(spec, invalidation_key: invalidation_key)
       if cached_gem
         @doc_sources[cache_key] = cached_gem.doc_source
         @loaded_gems[cache_key] = cached_gem
@@ -156,7 +152,7 @@ module GemDocs
 
       loaded_gem = build_loaded_gem(spec)
       @doc_sources[cache_key] = loaded_gem.doc_source
-      @cache&.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
+      persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
     end
 
@@ -244,6 +240,32 @@ module GemDocs
       end
 
       files.uniq
+    end
+
+    def safe_artifact_invalidation_key(spec)
+      artifact_invalidation_key(spec)
+    rescue StandardError
+      nil
+    end
+
+    def fetch_cached_loaded_gem(spec, invalidation_key:)
+      return unless @cache && invalidation_key
+
+      @cache.fetch_loaded_gem(
+        gem_name: spec.name,
+        gem_version: spec.version.to_s,
+        invalidation_key: invalidation_key
+      )
+    rescue StandardError
+      nil
+    end
+
+    def persist_loaded_gem(loaded_gem, invalidation_key:)
+      return unless @cache && invalidation_key
+
+      @cache.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
+    rescue StandardError
+      nil
     end
 
     def cache_key_for(name, version)

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -125,7 +125,7 @@ module GemDocs
       @loaded_gems = {}
       @doc_sources = {}
       @shell_runner = shell_runner || method(:run_command)
-      @cache = cache.nil? ? GemDocs::ArtifactCache.default(root: Dir.pwd) : cache
+      @cache = cache == false ? nil : (cache || GemDocs::ArtifactCache.default(root: Dir.pwd))
     end
 
     def load_gem(name, version: nil)

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -221,8 +221,10 @@ module GemDocs
       digest << "path:#{spec.full_gem_path}\n"
 
       artifact_files_for(spec).sort.each do |file|
+        stat = File.stat(file)
         digest << "file:#{file.delete_prefix("#{spec.full_gem_path}/")}\n"
-        digest << File.binread(file)
+        digest << "size:#{stat.size}\n"
+        digest << "mtime:#{stat.mtime.to_r}\n"
       end
 
       digest.hexdigest
@@ -232,13 +234,6 @@ module GemDocs
       files = ruby_files_for(spec)
       yardoc = yardoc_path_for(spec)
       files << yardoc if File.file?(yardoc)
-
-      if File.directory?(spec.doc_dir)
-        files.concat(
-          Dir.glob(File.join(spec.doc_dir, "**", "*")).select { |path| File.file?(path) }
-        )
-      end
-
       files.uniq
     end
 
@@ -251,11 +246,14 @@ module GemDocs
     def fetch_cached_loaded_gem(spec, invalidation_key:)
       return unless @cache && invalidation_key
 
-      @cache.fetch_loaded_gem(
+      cached_gem = @cache.fetch_loaded_gem(
         gem_name: spec.name,
         gem_version: spec.version.to_s,
         invalidation_key: invalidation_key
       )
+      return unless cached_gem
+
+      hydrate_cached_loaded_gem(spec, cached_gem)
     rescue StandardError
       nil
     end
@@ -266,6 +264,25 @@ module GemDocs
       @cache.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
     rescue StandardError
       nil
+    end
+
+    def hydrate_cached_loaded_gem(spec, loaded_gem)
+      return loaded_gem unless loaded_gem.doc_source == :rdoc
+
+      LoadedGem.new(
+        name: loaded_gem.name,
+        version: loaded_gem.version,
+        summary: loaded_gem.summary,
+        description: loaded_gem.description,
+        homepage: loaded_gem.homepage,
+        license: loaded_gem.license,
+        path: loaded_gem.path,
+        doc_source: loaded_gem.doc_source,
+        objects: loaded_gem.objects,
+        entry_points: loaded_gem.entry_points,
+        dynamic_lookup: ->(path) { load_rdoc_object(spec, path) },
+        lazy_paths: loaded_gem.objects.map(&:path)
+      )
     end
 
     def cache_key_for(name, version)

--- a/sig/deps/fileutils.rbs
+++ b/sig/deps/fileutils.rbs
@@ -1,0 +1,3 @@
+module FileUtils
+  def self.mkdir_p: (String path) -> untyped
+end

--- a/sig/deps/sqlite3.rbs
+++ b/sig/deps/sqlite3.rbs
@@ -1,0 +1,9 @@
+module SQLite3
+  class Database
+    def initialize: (String path) -> void
+    def execute_batch: (String sql) -> untyped
+    def execute: (String sql, *untyped bind_vars) -> Array[Array[untyped]]
+    def get_first_row: (String sql, *untyped bind_vars) -> Array[untyped]?
+    def close: -> void
+  end
+end

--- a/sig/deps/sqlite3.rbs
+++ b/sig/deps/sqlite3.rbs
@@ -1,6 +1,16 @@
 module SQLite3
+  class Exception < StandardError
+  end
+
+  class BusyException < Exception
+  end
+
+  class LockedException < Exception
+  end
+
   class Database
     def initialize: (String path) -> void
+    def busy_timeout=: (Integer timeout) -> Integer
     def execute_batch: (String sql) -> untyped
     def execute: (String sql, *untyped bind_vars) -> Array[Array[untyped]]
     def get_first_row: (String sql, *untyped bind_vars) -> Array[untyped]?

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -181,6 +181,11 @@ module GemDocs
     def cache_key_for: (String name, String? version) -> (String | [String, String])
     def normalize_version: (String? version) -> String?
     def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
+    def safe_artifact_invalidation_key: (Gem::Specification spec) -> String?
+    def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> LoadedGem?
+    def persist_loaded_gem: (LoadedGem loaded_gem, invalidation_key: String?) -> void?
+    def artifact_invalidation_key: (Gem::Specification spec) -> String
+    def artifact_files_for: (Gem::Specification spec) -> Array[String]
     def load_yard_objects: (String yardoc) -> Array[Entry]
     def gem_description: (Gem::Specification spec) -> String?
     def gem_license: (Gem::Specification spec) -> String?

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -168,7 +168,7 @@ module GemDocs
 
     def self.gem_spec_for: (String name, ?version: String?) -> Gem::Specification?
 
-    def initialize: (?shell_runner: ^(Array[String]) -> command_response) -> void
+    def initialize: (?shell_runner: ^(Array[String]) -> command_response, ?cache: ArtifactCache?) -> void
     def load_gem: (String name, ?version: String?) -> LoadedGem
     def doc_source_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> doc_source
     def find_object: (String path, gem_name: String) -> Entry?
@@ -221,6 +221,53 @@ module GemDocs
     def command_execution_failed?: (command_response response) -> bool
     def push_children: (Array[[Prism::Node, String?, bool]] stack, Prism::Node node, String? namespace_path, ?bool class_method_context) -> Array[[Prism::Node, String?, bool]]?
     def find_in_ancestor_chain: (LoadedGem loaded_gem, String path) -> Entry?
+  end
+
+  class ArtifactCache
+    SCHEMA_VERSION: Integer
+    GEM_LOOKUP_TARGET: String
+    ARTIFACT_VERSIONS: Hash[Symbol, Integer]
+
+    def self.default: (?root: String) -> ArtifactCache
+
+    def initialize: (path: String) -> void
+    def fetch_loaded_gem: (gem_name: String, gem_version: String, invalidation_key: String) -> DocRegistry::LoadedGem?
+    def write_loaded_gem: (DocRegistry::LoadedGem loaded_gem, invalidation_key: String) -> true
+    def fetch_artifact: (
+      gem_name: String,
+      gem_version: String,
+      lookup_target: String,
+      artifact_kind: Symbol,
+      invalidation_key: String,
+      ?artifact_version: Integer?
+    ) -> untyped
+    def fetch_with_fallback: (
+      gem_name: String,
+      gem_version: String,
+      lookup_target: String,
+      invalidation_key: String
+    ) -> { kind: Symbol, payload: untyped }?
+    def write_artifact: (
+      gem_name: String,
+      gem_version: String,
+      lookup_target: String,
+      artifact_kind: Symbol,
+      payload: untyped,
+      invalidation_key: String,
+      ?artifact_version: Integer?
+    ) -> true
+
+    private
+
+    attr_reader path: String
+    def with_database: { (SQLite3::Database database) -> untyped } -> untyped
+    def ensure_schema!: (SQLite3::Database database) -> void
+    def serialize_loaded_gem: (DocRegistry::LoadedGem loaded_gem) -> Hash[String, untyped]
+    def serialize_entry: (DocRegistry::Entry entry) -> Hash[String, untyped]
+    def build_loaded_gem: (Hash[String, untyped] payload) -> DocRegistry::LoadedGem
+    def build_entry: (Hash[String, untyped] payload) -> DocRegistry::Entry
+    def symbolize_hash: (untyped value) -> untyped
+    def default_artifact_version: (Symbol artifact_kind) -> Integer
   end
 
   module Commands

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -183,6 +183,7 @@ module GemDocs
     def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
     def safe_artifact_invalidation_key: (Gem::Specification spec) -> String?
     def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> LoadedGem?
+    def hydrate_cached_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem
     def persist_loaded_gem: (LoadedGem loaded_gem, invalidation_key: String?) -> bool?
     def artifact_invalidation_key: (Gem::Specification spec) -> String
     def artifact_files_for: (Gem::Specification spec) -> Array[String]
@@ -230,6 +231,9 @@ module GemDocs
 
   class ArtifactCache
     SCHEMA_VERSION: Integer
+    BUSY_TIMEOUT_MS: Integer
+    MAX_BUSY_RETRIES: Integer
+    BUSY_RETRY_DELAY: Float
     GEM_LOOKUP_TARGET: String
     ARTIFACT_VERSIONS: Hash[Symbol, Integer]
 
@@ -265,7 +269,7 @@ module GemDocs
     private
 
     attr_reader path: String
-    def with_database: { (SQLite3::Database database) -> untyped } -> untyped
+    def with_database: (?Integer attempt) { (SQLite3::Database database) -> untyped } -> untyped
     def ensure_schema!: (SQLite3::Database database) -> void
     def serialize_loaded_gem: (DocRegistry::LoadedGem loaded_gem) -> Hash[String, untyped]
     def serialize_entry: (DocRegistry::Entry entry) -> Hash[String, untyped]

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -183,7 +183,7 @@ module GemDocs
     def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
     def safe_artifact_invalidation_key: (Gem::Specification spec) -> String?
     def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> LoadedGem?
-    def persist_loaded_gem: (LoadedGem loaded_gem, invalidation_key: String?) -> void?
+    def persist_loaded_gem: (LoadedGem loaded_gem, invalidation_key: String?) -> bool?
     def artifact_invalidation_key: (Gem::Specification spec) -> String
     def artifact_files_for: (Gem::Specification spec) -> Array[String]
     def load_yard_objects: (String yardoc) -> Array[Entry]

--- a/spec/artifact_cache_spec.rb
+++ b/spec/artifact_cache_spec.rb
@@ -5,6 +5,60 @@ require "spec_helper"
 require "gem_docs"
 
 RSpec.describe GemDocs::ArtifactCache do
+  it "configures a busy timeout for SQLite connections" do
+    Dir.mktmpdir do |tmpdir|
+      cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+      database = instance_double(SQLite3::Database)
+
+      allow(SQLite3::Database).to receive(:new).and_return(database)
+      allow(database).to receive(:execute_batch)
+      allow(database).to receive(:get_first_row).and_return([ described_class::SCHEMA_VERSION.to_s ])
+      allow(database).to receive(:execute)
+      allow(database).to receive(:close)
+
+      expect(database).to receive(:busy_timeout=).with(described_class::BUSY_TIMEOUT_MS)
+
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :source,
+        payload: { "docstring" => "Full source docs" },
+        invalidation_key: "digest-v1"
+      )
+    end
+  end
+
+  it "retries writes when SQLite reports the database is locked" do
+    Dir.mktmpdir do |tmpdir|
+      cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+      database = instance_double(SQLite3::Database)
+
+      allow(SQLite3::Database).to receive(:new).and_return(database)
+      allow(database).to receive(:busy_timeout=)
+      allow(database).to receive(:execute_batch)
+      allow(database).to receive(:get_first_row).and_return([ described_class::SCHEMA_VERSION.to_s ])
+      allow(database).to receive(:close)
+      allow(cache).to receive(:sleep)
+
+      attempts = 0
+      allow(database).to receive(:execute) do
+        attempts += 1
+        raise SQLite3::BusyException, "database is locked" if attempts == 1
+      end
+
+      expect(cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :source,
+        payload: { "docstring" => "Full source docs" },
+        invalidation_key: "digest-v1"
+      )).to be(true)
+      expect(attempts).to eq(2)
+    end
+  end
+
   it "keeps source and compressed artifacts separate and falls back to source artifacts" do
     Dir.mktmpdir do |tmpdir|
       cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))

--- a/spec/artifact_cache_spec.rb
+++ b/spec/artifact_cache_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::ArtifactCache do
+  it "keeps source and compressed artifacts separate and falls back to source artifacts" do
+    Dir.mktmpdir do |tmpdir|
+      cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :source,
+        payload: { "docstring" => "Full source docs" },
+        invalidation_key: "digest-v1"
+      )
+
+      expect(cache.fetch_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :compressed,
+        invalidation_key: "digest-v1"
+      )).to be_nil
+
+      expect(cache.fetch_with_fallback(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        invalidation_key: "digest-v1"
+      )).to eq(
+        {
+          kind: :source,
+          payload: { "docstring" => "Full source docs" }
+        }
+      )
+
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :compressed,
+        payload: { "summary" => "Short summary" },
+        invalidation_key: "digest-v1"
+      )
+
+      expect(cache.fetch_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :source,
+        invalidation_key: "digest-v1"
+      )).to eq({ "docstring" => "Full source docs" })
+      expect(cache.fetch_with_fallback(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        invalidation_key: "digest-v1"
+      )).to eq(
+        {
+          kind: :compressed,
+          payload: { "summary" => "Short summary" }
+        }
+      )
+    end
+  end
+
+  it "separates persisted artifacts by gem version" do
+    Dir.mktmpdir do |tmpdir|
+      cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget",
+        artifact_kind: :source,
+        payload: { "version" => "1.0.0" },
+        invalidation_key: "digest-v1"
+      )
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "2.0.0",
+        lookup_target: "Demo::Widget",
+        artifact_kind: :source,
+        payload: { "version" => "2.0.0" },
+        invalidation_key: "digest-v2"
+      )
+
+      expect(cache.fetch_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget",
+        artifact_kind: :source,
+        invalidation_key: "digest-v1"
+      )).to eq({ "version" => "1.0.0" })
+      expect(cache.fetch_artifact(
+        gem_name: "demo",
+        gem_version: "2.0.0",
+        lookup_target: "Demo::Widget",
+        artifact_kind: :source,
+        invalidation_key: "digest-v2"
+      )).to eq({ "version" => "2.0.0" })
+    end
+  end
+end

--- a/spec/bootstrap_structure_spec.rb
+++ b/spec/bootstrap_structure_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "bootstrap structure" do
     expect(spec.required_ruby_version).to eq(Gem::Requirement.new(">= 3.2"))
     expect(spec.executables).to contain_exactly("gem-docs", "gem-docs-server")
     expect(spec.version.to_s).to eq(GemDocs::VERSION)
-    expect(spec.runtime_dependencies.map(&:name)).to contain_exactly("dry-cli", "prism", "yard", "zeitwerk")
+    expect(spec.runtime_dependencies.map(&:name)).to contain_exactly("dry-cli", "prism", "sqlite3", "yard", "zeitwerk")
 
     expect(gemfile).to include('group :mcp do')
     expect(gemfile).to include('gem "fast-mcp", require: false')

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -71,6 +71,66 @@ RSpec.describe GemDocs::DocRegistry do
       end
     end
 
+    it "reuses persisted documentation artifacts across registry instances" do
+      with_source_fixture_gem("persistent_fixture", source: <<~RUBY) do
+        module PersistentFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        Dir.mktmpdir do |tmpdir|
+          cache_path = File.join(tmpdir, "artifacts.sqlite3")
+          first_registry = described_class.new(cache: GemDocs::ArtifactCache.new(path: cache_path))
+
+          first_registry.load_gem("persistent_fixture")
+
+          second_registry = described_class.new(cache: GemDocs::ArtifactCache.new(path: cache_path))
+          expect(second_registry).not_to receive(:build_loaded_gem)
+
+          loaded_gem = second_registry.load_gem("persistent_fixture")
+
+          expect(loaded_gem.doc_source).to eq(:source_only)
+          expect(second_registry.find_object("PersistentFixture::Widget#call", gem_name: "persistent_fixture")&.signature)
+            .to eq("PersistentFixture::Widget#call(input)")
+        end
+      end
+    end
+
+    it "invalidates persisted documentation artifacts when gem contents change" do
+      with_source_fixture_gem("mutable_fixture", source: <<~RUBY) do |spec|
+        module MutableFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        Dir.mktmpdir do |tmpdir|
+          cache_path = File.join(tmpdir, "artifacts.sqlite3")
+          first_registry = described_class.new(cache: GemDocs::ArtifactCache.new(path: cache_path))
+
+          expect(first_registry.find_object("MutableFixture::Widget#call", gem_name: "mutable_fixture")&.signature)
+            .to eq("MutableFixture::Widget#call(input)")
+
+          File.write(File.join(spec.full_gem_path, "lib", "mutable_fixture.rb"), <<~RUBY)
+            module MutableFixture
+              class Widget
+                def call(input, retries: 0)
+                end
+              end
+            end
+          RUBY
+
+          second_registry = described_class.new(cache: GemDocs::ArtifactCache.new(path: cache_path))
+
+          expect(second_registry.find_object("MutableFixture::Widget#call", gem_name: "mutable_fixture")&.signature)
+            .to eq("MutableFixture::Widget#call(input, retries: ?)")
+        end
+      end
+    end
+
     it "falls back to ri data when a gem has no .yardoc cache" do
       stub_fixture_gem("rdoc_only", registry_class: described_class) do |spec|
         commands = []

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -71,6 +71,16 @@ RSpec.describe GemDocs::DocRegistry do
       end
     end
 
+    it "allows persistent caching to be disabled explicitly" do
+      with_source_fixture_gem("cache_toggle_fixture", source: "module CacheToggleFixture; end\n") do
+        expect(GemDocs::ArtifactCache).not_to receive(:default)
+
+        registry = described_class.new(cache: false)
+
+        expect(registry.load_gem("cache_toggle_fixture").doc_source).to eq(:source_only)
+      end
+    end
+
     it "reuses persisted documentation artifacts across registry instances" do
       with_source_fixture_gem("persistent_fixture", source: <<~RUBY) do
         module PersistentFixture

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -141,6 +141,68 @@ RSpec.describe GemDocs::DocRegistry do
       end
     end
 
+    it "rebuilds from source when a persisted cache entry is corrupted" do
+      with_source_fixture_gem("corrupt_cache_fixture", source: <<~RUBY) do |spec|
+        module CorruptCacheFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        Dir.mktmpdir do |tmpdir|
+          cache_path = File.join(tmpdir, "artifacts.sqlite3")
+          cache = GemDocs::ArtifactCache.new(path: cache_path)
+          registry = described_class.new(cache: cache)
+          invalidation_key = registry.send(:artifact_invalidation_key, spec)
+
+          cache.write_artifact(
+            gem_name: "corrupt_cache_fixture",
+            gem_version: "0.1.0",
+            lookup_target: GemDocs::ArtifactCache::GEM_LOOKUP_TARGET,
+            artifact_kind: :source,
+            payload: { "name" => "bad" },
+            invalidation_key: invalidation_key
+          )
+
+          SQLite3::Database.new(cache_path).tap do |database|
+            database.execute(
+              "UPDATE documentation_artifacts SET payload = ? WHERE gem_name = ?",
+              "{",
+              "corrupt_cache_fixture"
+            )
+          ensure
+            database.close
+          end
+
+          rebuilt_registry = described_class.new(cache: cache)
+
+          expect(rebuilt_registry.find_object("CorruptCacheFixture::Widget#call", gem_name: "corrupt_cache_fixture")&.signature)
+            .to eq("CorruptCacheFixture::Widget#call(input)")
+        end
+      end
+    end
+
+    it "treats invalidation key read failures as cache misses" do
+      with_source_fixture_gem("invalidation_failure_fixture", source: <<~RUBY) do |spec|
+        module InvalidationFailureFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        source_path = File.join(spec.full_gem_path, "lib", "invalidation_failure_fixture.rb")
+        allow(File).to receive(:binread).and_call_original
+        allow(File).to receive(:binread).with(source_path).and_raise(Errno::ENOENT, source_path)
+
+        registry = described_class.new(cache: GemDocs::ArtifactCache.new(path: File.join(spec.full_gem_path, "cache.sqlite3")))
+
+        expect(registry.find_object("InvalidationFailureFixture::Widget#call", gem_name: "invalidation_failure_fixture")&.signature)
+          .to eq("InvalidationFailureFixture::Widget#call(input)")
+      end
+    end
+
     it "falls back to ri data when a gem has no .yardoc cache" do
       stub_fixture_gem("rdoc_only", registry_class: described_class) do |spec|
         commands = []

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -193,8 +193,8 @@ RSpec.describe GemDocs::DocRegistry do
         end
       RUBY
         source_path = File.join(spec.full_gem_path, "lib", "invalidation_failure_fixture.rb")
-        allow(File).to receive(:binread).and_call_original
-        allow(File).to receive(:binread).with(source_path).and_raise(Errno::ENOENT, source_path)
+        allow(File).to receive(:stat).and_call_original
+        allow(File).to receive(:stat).with(source_path).and_raise(Errno::ENOENT, source_path)
 
         registry = described_class.new(cache: GemDocs::ArtifactCache.new(path: File.join(spec.full_gem_path, "cache.sqlite3")))
 
@@ -231,6 +231,49 @@ RSpec.describe GemDocs::DocRegistry do
         expect(commands.count { |command| command.last == "RdocOnly::Widget" }).to eq(0)
         expect(object&.doc_source).to eq(:rdoc)
         expect(object&.docstring).to include("Calls through ri.")
+      end
+    end
+
+    it "rebuilds cached rdoc gems with lazy ri lookups across registry instances" do
+      stub_fixture_gem("rdoc_only", registry_class: described_class) do
+        Dir.mktmpdir do |tmpdir|
+          cache_path = File.join(tmpdir, "artifacts.sqlite3")
+          commands = []
+
+          shell_runner = lambda do |command|
+            commands << command
+
+            case command.last
+            when "-l"
+              { stdout: "RdocOnly::Widget\n", stderr: "", success: true }
+            when "RdocOnly::Widget"
+              { stdout: "class RdocOnly::Widget\n\nThe primary RDoc class.\n", stderr: "", success: true }
+            when "RdocOnly::Widget#call"
+              { stdout: "RdocOnly::Widget#call\n\nCalls through ri.\n", stderr: "", success: true }
+            else
+              { stdout: "", stderr: "Not found", success: false }
+            end
+          end
+
+          first_registry = described_class.new(
+            shell_runner: shell_runner,
+            cache: GemDocs::ArtifactCache.new(path: cache_path)
+          )
+          first_registry.load_gem("rdoc_only")
+
+          commands.clear
+
+          second_registry = described_class.new(
+            shell_runner: shell_runner,
+            cache: GemDocs::ArtifactCache.new(path: cache_path)
+          )
+          object = second_registry.find_object("RdocOnly::Widget#call", gem_name: "rdoc_only")
+
+          expect(object&.doc_source).to eq(:rdoc)
+          expect(object&.docstring).to include("Calls through ri.")
+          expect(commands.map(&:last)).to include("RdocOnly::Widget#call")
+          expect(commands.map(&:last)).not_to include("-l")
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- add a persistent SQLite-backed artifact cache for normalized gem documentation
- reuse cached loaded-gem artifacts across registry instances with invalidation based on gem contents and cache versions
- store source and compressed artifacts separately and document the cache contract

Closes #30

## Test plan
- bundle exec rspec
- bundle exec rubocop -a
- bundle exec steep check