### PR TITLE
feat: add offline gem knowledge compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,64 @@ CLI-first gem documentation lookup for local Ruby projects, with an optional MCP
 The cache keeps source-derived artifacts and future compressed artifacts in separate rows keyed by gem name, gem version, and lookup target.
 Entries are invalidated automatically when the gem contents change or when the cache schema/artifact version changes.
 
+## Offline compression for non-obvious knowledge
+
+The cache now persists per-entry source artifacts alongside the whole-gem snapshot so an offline preprocessing pass can read normalized lookup payloads from SQLite and write compressed knowledge back into the same database.
+
+`GemDocs::Compression::Pipeline` is the offline entrypoint. It accepts an injected compressor callable, reads the current source artifacts for a gem/version from the cache, and stores compressed rows under the same gem/version/lookup-target key space using `artifact_kind = compressed`.
+
+### What counts as non-obvious knowledge
+
+Keep only gem-specific details that a strong model is unlikely to infer from general Ruby knowledge:
+
+- surprising behavior
+- caveats and footguns
+- conventions that are specific to the gem
+- edge cases and fallback rules
+- version-scoped behavior changes
+
+If a source artifact contains only obvious API surface information, the compressor should return `status: "insufficient"` so runtime lookup falls back to the raw source-derived artifact.
+
+### Prompt and schema
+
+The pipeline ships a documented prompt definition in `GemDocs::Compression::Pipeline::NON_OBVIOUS_KNOWLEDGE_DEFINITION` and validates compressor output against the `OUTPUT_SCHEMA` shape:
+
+```json
+{
+  "status": "ready | insufficient",
+  "reason": "optional explanation when compression is insufficient",
+  "insights": [
+    {
+      "title": "short finding",
+      "detail": "non-obvious gem-specific behavior",
+      "categories": ["behavior", "edge_case"],
+      "version_scope": "optional version note"
+    }
+  ]
+}
+```
+
+Each compressed payload also stores:
+
+- `prompt_version`
+- `source_artifact.lookup_target`
+- `source_artifact.artifact_kind`
+- `source_artifact.artifact_version`
+- `source_artifact.invalidation_key`
+- `source_artifact.payload_digest`
+
+That linkage lets runtime lookup distinguish compressed insight from raw documentation and safely fall back when compressed knowledge is missing or insufficient.
+
+### Evaluation approach
+
+Evaluate compression on a small representative gem set (for example: an HTTP client, a Rails-adjacent utility, and a source-only gem fixture) and compare:
+
+1. the raw source-derived artifact
+2. the compressed insights
+3. the runtime lookup result after fallback rules are applied
+
+A compression pass is acceptable only when the compressed payload preserves the important gem-specific caveats and lookup still returns raw/source-derived documentation whenever compression is absent or marked insufficient.
+
 ## CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If a source artifact contains only obvious API surface information, the compress
 
 ### Prompt and schema
 
-The pipeline ships a documented prompt definition in `GemDocs::Compression::Pipeline::NON_OBVIOUS_KNOWLEDGE_DEFINITION` and validates compressor output against the `OUTPUT_SCHEMA` shape:
+The pipeline ships a documented prompt definition in `GemDocs::Compression::Pipeline::NON_OBVIOUS_KNOWLEDGE_DEFINITION` and validates the compressor response against the `OUTPUT_SCHEMA` shape before adding cache metadata:
 
 ```json
 {

--- a/Steepfile
+++ b/Steepfile
@@ -9,6 +9,7 @@ target :lib do
   ignore "lib/gem_docs/formatters/context.rb"
 
   library "json"
+  library "digest"
   library "open3"
   library "pathname"
   library "yaml"

--- a/lib/gem_docs/artifact_cache.rb
+++ b/lib/gem_docs/artifact_cache.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "digest"
 require "json"
 require "sqlite3"
 
@@ -81,7 +82,7 @@ module GemDocs
         artifact_kind: :compressed,
         invalidation_key: invalidation_key
       )
-      return { kind: :compressed, payload: compressed } if compressed
+      return { kind: :compressed, payload: compressed } if compressed_usable?(compressed)
 
       source = fetch_artifact(
         gem_name: gem_name,
@@ -93,6 +94,36 @@ module GemDocs
       return { kind: :source, payload: source } if source
 
       nil
+    end
+
+    def source_artifacts(gem_name:, gem_version:, invalidation_key:)
+      with_database do |database|
+        database.execute(
+          <<~SQL,
+            SELECT lookup_target, artifact_version, invalidation_key, payload
+            FROM documentation_artifacts
+            WHERE gem_name = ?
+              AND gem_version = ?
+              AND artifact_kind = 'source'
+              AND invalidation_key = ?
+              AND lookup_target != ?
+            ORDER BY lookup_target ASC
+          SQL
+          gem_name,
+          gem_version,
+          invalidation_key,
+          GEM_LOOKUP_TARGET
+        ).map do |lookup_target, artifact_version, row_invalidation_key, payload|
+          parsed_payload = JSON.parse(payload)
+          {
+            lookup_target: lookup_target,
+            artifact_version: artifact_version,
+            invalidation_key: row_invalidation_key,
+            payload: parsed_payload,
+            payload_digest: artifact_payload_digest(parsed_payload)
+          }
+        end
+      end
     end
 
     def write_artifact(gem_name:, gem_version:, lookup_target:, artifact_kind:, payload:, invalidation_key:, artifact_version: nil)
@@ -268,6 +299,17 @@ module GemDocs
 
     def default_artifact_version(artifact_kind)
       ARTIFACT_VERSIONS.fetch(artifact_kind.to_sym)
+    end
+
+    def compressed_usable?(payload)
+      return false unless payload
+      return false if payload.is_a?(Hash) && payload["status"] == "insufficient"
+
+      true
+    end
+
+    def artifact_payload_digest(payload)
+      Digest::SHA256.hexdigest(JSON.generate(payload))
     end
   end
 end

--- a/lib/gem_docs/commands/lookup.rb
+++ b/lib/gem_docs/commands/lookup.rb
@@ -92,8 +92,13 @@ module GemDocs
 
       def lookup_payload(result)
         entry = result.fetch(:entry)
+        cached_artifact = doc_registry.lookup_artifact_for(
+          entry.path,
+          gem_name: result.fetch(:gem_name),
+          version: result.fetch(:version)
+        )
 
-        {
+        payload = {
           path: entry.path,
           name: entry.name,
           kind: entry.kind,
@@ -107,6 +112,15 @@ module GemDocs
           source_location: entry.source_location,
           aliases: entry.aliases
         }
+
+        return payload unless cached_artifact
+
+        payload[:knowledge_source] = cached_artifact.fetch(:kind)
+        if cached_artifact.fetch(:kind) == :compressed
+          payload[:non_obvious_insights] = cached_artifact.fetch(:payload).fetch("insights", Array.new)
+        end
+
+        payload
       end
     end
   end

--- a/lib/gem_docs/compression.rb
+++ b/lib/gem_docs/compression.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module Compression
+  end
+end

--- a/lib/gem_docs/compression/pipeline.rb
+++ b/lib/gem_docs/compression/pipeline.rb
@@ -99,9 +99,7 @@ module GemDocs
       end
 
       def normalize_payload(payload, source_artifact:)
-        normalized = (payload || {}).transform_keys(&:to_s)
-        normalized["status"] ||= "ready"
-        normalized["insights"] = Array(normalized["insights"]).map { |insight| stringify_insight(insight) }
+        normalized = normalize_compressor_payload(payload)
         normalized["prompt_version"] = PROMPT_VERSION
         normalized["source_artifact"] = {
           "lookup_target" => source_artifact.fetch(:lookup_target),
@@ -111,6 +109,62 @@ module GemDocs
           "payload_digest" => source_artifact.fetch(:payload_digest)
         }
         normalized
+      end
+
+      def normalize_compressor_payload(payload)
+        raise ArgumentError, "Compressor output must be a Hash or nil" unless payload.nil? || payload.is_a?(Hash)
+
+        normalized = payload&.transform_keys(&:to_s) || {}
+        return insufficient_payload("Compressor returned no structured payload") if normalized.empty?
+
+        normalized["status"] = normalized.fetch("status").to_s
+        normalized["reason"] = normalized["reason"].to_s if normalized.key?("reason") && !normalized["reason"].nil?
+        normalized["insights"] = Array(normalized.fetch("insights")).map { |insight| stringify_insight(insight) }
+        validate_payload!(normalized)
+        normalized
+      end
+
+      def insufficient_payload(reason)
+        {
+          "status" => "insufficient",
+          "reason" => reason,
+          "insights" => []
+        }
+      end
+
+      def validate_payload!(payload)
+        unless OUTPUT_SCHEMA.fetch("properties").fetch("status").fetch("enum").include?(payload["status"])
+          raise ArgumentError, "Compressor output has invalid status: #{payload['status'].inspect}"
+        end
+
+        raise ArgumentError, "Compressor output must include an insights array" unless payload["insights"].is_a?(Array)
+
+        if payload.key?("reason") && !payload["reason"].is_a?(String)
+          raise ArgumentError, "Compressor output reason must be a string"
+        end
+
+        payload["insights"].each do |insight|
+          validate_insight!(insight)
+        end
+      end
+
+      def validate_insight!(insight)
+        raise ArgumentError, "Each insight must be an object" unless insight.is_a?(Hash)
+
+        title = insight["title"]
+        detail = insight["detail"]
+        raise ArgumentError, "Each insight must include a string title" unless title.is_a?(String)
+        raise ArgumentError, "Each insight must include a string detail" unless detail.is_a?(String)
+
+        categories = insight["categories"]
+        if !categories.nil? && (!categories.is_a?(Array) || categories.any? { |value| !value.is_a?(String) })
+          raise ArgumentError, "Insight categories must be an array of strings"
+        end
+
+        version_scope = insight["version_scope"]
+        return if version_scope.nil? || version_scope.is_a?(String)
+
+        raise ArgumentError, "Insight version_scope must be a string"
       end
 
       def stringify_insight(insight)

--- a/lib/gem_docs/compression/pipeline.rb
+++ b/lib/gem_docs/compression/pipeline.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "json"
+
+module GemDocs
+  module Compression
+    class Pipeline
+      PROMPT_VERSION = 1
+      NON_OBVIOUS_KNOWLEDGE_DEFINITION = <<~TEXT.freeze
+        Extract only gem-specific knowledge that is unlikely to be obvious from a strong model's prior knowledge:
+        surprising behavior, caveats, conventions, edge cases, and version-specific details.
+        If the source artifact contains only obvious API surface information, return status="insufficient".
+      TEXT
+      OUTPUT_SCHEMA = {
+        "type" => "object",
+        "required" => [ "status", "insights" ],
+        "properties" => {
+          "status" => {
+            "type" => "string",
+            "enum" => [ "ready", "insufficient" ]
+          },
+          "reason" => {
+            "type" => "string"
+          },
+          "insights" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "required" => [ "title", "detail" ],
+              "properties" => {
+                "title" => { "type" => "string" },
+                "detail" => { "type" => "string" },
+                "categories" => {
+                  "type" => "array",
+                  "items" => { "type" => "string" }
+                },
+                "version_scope" => { "type" => "string" }
+              }
+            }
+          }
+        }
+      }.freeze
+
+      def initialize(cache:, compressor:, doc_registry: GemDocs::DocRegistry.new(cache: cache))
+        @cache = cache
+        @compressor = compressor
+        @doc_registry = doc_registry
+      end
+
+      def compress_gem(gem_name, version: nil)
+        loaded_gem = @doc_registry.load_gem(gem_name, version: version)
+        invalidation_key = @doc_registry.artifact_invalidation_key_for(gem_name, version: loaded_gem.version)
+        source_artifacts = @doc_registry.source_artifacts_for(gem_name, version: loaded_gem.version)
+
+        source_artifacts.each do |source_artifact|
+          compressed_payload = normalize_payload(
+            @compressor.call(
+              gem: {
+                name: loaded_gem.name,
+                version: loaded_gem.version,
+                doc_source: loaded_gem.doc_source.to_s
+              },
+              source_artifact: source_artifact,
+              prompt: prompt_for(loaded_gem, source_artifact),
+              schema: OUTPUT_SCHEMA
+            ),
+            source_artifact: source_artifact
+          )
+
+          @cache.write_artifact(
+            gem_name: loaded_gem.name,
+            gem_version: loaded_gem.version,
+            lookup_target: source_artifact.fetch(:lookup_target),
+            artifact_kind: :compressed,
+            payload: compressed_payload,
+            invalidation_key: invalidation_key
+          )
+        end
+
+        {
+          gem_name: loaded_gem.name,
+          gem_version: loaded_gem.version,
+          compressed_count: source_artifacts.length
+        }
+      end
+
+      private
+
+      def prompt_for(loaded_gem, source_artifact)
+        <<~TEXT
+          Compress non-obvious knowledge for #{loaded_gem.name} #{loaded_gem.version}.
+
+          #{NON_OBVIOUS_KNOWLEDGE_DEFINITION}
+
+          Lookup target: #{source_artifact.fetch(:lookup_target)}
+          Source payload:
+          #{source_artifact.fetch(:payload).to_json}
+        TEXT
+      end
+
+      def normalize_payload(payload, source_artifact:)
+        normalized = (payload || {}).transform_keys(&:to_s)
+        normalized["status"] ||= "ready"
+        normalized["insights"] = Array(normalized["insights"]).map { |insight| stringify_insight(insight) }
+        normalized["prompt_version"] = PROMPT_VERSION
+        normalized["source_artifact"] = {
+          "lookup_target" => source_artifact.fetch(:lookup_target),
+          "artifact_kind" => "source",
+          "artifact_version" => source_artifact.fetch(:artifact_version),
+          "invalidation_key" => source_artifact.fetch(:invalidation_key),
+          "payload_digest" => source_artifact.fetch(:payload_digest)
+        }
+        normalized
+      end
+
+      def stringify_insight(insight)
+        case insight
+        when Hash
+          stringified = Hash.new
+          insight.each do |key, value|
+            stringified[key.to_s] = value
+          end
+          stringified
+        else
+          { "detail" => insight.to_s }
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -147,6 +147,7 @@ module GemDocs
       if cached_gem
         @doc_sources[cache_key] = cached_gem.doc_source
         @loaded_gems[cache_key] = cached_gem
+        ensure_source_artifacts_persisted(cached_gem, invalidation_key: invalidation_key)
         return cached_gem
       end
 
@@ -186,11 +187,7 @@ module GemDocs
       invalidation_key = artifact_invalidation_key_for(name, version: loaded_gem.version)
       return [] unless @cache && invalidation_key
 
-      @cache.source_artifacts(
-        gem_name: loaded_gem.name,
-        gem_version: loaded_gem.version,
-        invalidation_key: invalidation_key
-      )
+      ensure_source_artifacts_persisted(loaded_gem, invalidation_key: invalidation_key)
     end
 
     def lookup_artifact_for(path, gem_name:, version: nil)
@@ -302,16 +299,37 @@ module GemDocs
     end
 
     def persist_source_artifacts(loaded_gem, invalidation_key:)
-      loaded_gem.objects.each do |entry|
+      loaded_gem.objects.dup.each do |entry|
+        resolved_entry = loaded_gem.find(entry.path) || entry
         @cache.write_artifact(
           gem_name: loaded_gem.name,
           gem_version: loaded_gem.version,
-          lookup_target: entry.path,
+          lookup_target: resolved_entry.path,
           artifact_kind: :source,
-          payload: source_artifact_payload(loaded_gem, entry),
+          payload: source_artifact_payload(loaded_gem, resolved_entry),
           invalidation_key: invalidation_key
         )
       end
+    end
+
+    def ensure_source_artifacts_persisted(loaded_gem, invalidation_key:)
+      return [] unless @cache && invalidation_key
+
+      artifacts = @cache.source_artifacts(
+        gem_name: loaded_gem.name,
+        gem_version: loaded_gem.version,
+        invalidation_key: invalidation_key
+      )
+      return artifacts unless artifacts.empty? && !loaded_gem.objects.empty?
+
+      persist_source_artifacts(loaded_gem, invalidation_key: invalidation_key)
+      @cache.source_artifacts(
+        gem_name: loaded_gem.name,
+        gem_version: loaded_gem.version,
+        invalidation_key: invalidation_key
+      )
+    rescue StandardError
+      []
     end
 
     def source_artifact_payload(loaded_gem, entry)

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -174,6 +174,40 @@ module GemDocs
       end
     end
 
+    def artifact_invalidation_key_for(name, version: nil)
+      spec = resolve_spec(name, version: version)
+      raise GemDocs::GemNotFound.new(name) unless spec
+
+      safe_artifact_invalidation_key(spec)
+    end
+
+    def source_artifacts_for(name, version: nil)
+      loaded_gem = load_gem(name, version: version)
+      invalidation_key = artifact_invalidation_key_for(name, version: loaded_gem.version)
+      return [] unless @cache && invalidation_key
+
+      @cache.source_artifacts(
+        gem_name: loaded_gem.name,
+        gem_version: loaded_gem.version,
+        invalidation_key: invalidation_key
+      )
+    end
+
+    def lookup_artifact_for(path, gem_name:, version: nil)
+      loaded_gem = load_gem(gem_name, version: version)
+      invalidation_key = artifact_invalidation_key_for(gem_name, version: loaded_gem.version)
+      return unless @cache && invalidation_key
+
+      @cache.fetch_with_fallback(
+        gem_name: loaded_gem.name,
+        gem_version: loaded_gem.version,
+        lookup_target: path,
+        invalidation_key: invalidation_key
+      )
+    rescue StandardError
+      nil
+    end
+
     def find_object(path, gem_name:)
       loaded_gem = load_gem(gem_name)
       loaded_gem.find(path) || find_in_ancestor_chain(loaded_gem, path)
@@ -262,8 +296,40 @@ module GemDocs
       return unless @cache && invalidation_key
 
       @cache.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
+      persist_source_artifacts(loaded_gem, invalidation_key: invalidation_key)
     rescue StandardError
       nil
+    end
+
+    def persist_source_artifacts(loaded_gem, invalidation_key:)
+      loaded_gem.objects.each do |entry|
+        @cache.write_artifact(
+          gem_name: loaded_gem.name,
+          gem_version: loaded_gem.version,
+          lookup_target: entry.path,
+          artifact_kind: :source,
+          payload: source_artifact_payload(loaded_gem, entry),
+          invalidation_key: invalidation_key
+        )
+      end
+    end
+
+    def source_artifact_payload(loaded_gem, entry)
+      {
+        "gem_name" => loaded_gem.name,
+        "gem_version" => loaded_gem.version,
+        "doc_source" => entry.doc_source.to_s,
+        "path" => entry.path,
+        "name" => entry.name,
+        "kind" => entry.kind.to_s,
+        "visibility" => entry.visibility.to_s,
+        "docstring" => entry.docstring,
+        "signature" => entry.signature,
+        "source_location" => entry.source_location,
+        "superclass" => entry.superclass,
+        "tags" => stringify_hash(entry.tags),
+        "aliases" => entry.aliases
+      }
     end
 
     def hydrate_cached_loaded_gem(spec, loaded_gem)
@@ -296,6 +362,13 @@ module GemDocs
       return nil if version.nil? || version.empty?
 
       version
+    end
+
+    def resolve_spec(name, version: nil)
+      normalized_version = normalize_version(version)
+      return self.class.gem_spec_for(name) if normalized_version.nil?
+
+      self.class.gem_spec_for(name, version: normalized_version)
     end
 
     def build_loaded_gem(spec)
@@ -765,6 +838,19 @@ module GemDocs
 
       Array(object.aliases).filter_map do |alias_object|
         alias_object.respond_to?(:path) ? alias_object.path : alias_object.to_s
+      end
+    end
+
+    def stringify_hash(value)
+      case value
+      when Hash
+        value.each_with_object({}) do |(key, nested_value), hash|
+          hash[key.to_s] = stringify_hash(nested_value)
+        end
+      when Array
+        value.map { |item| stringify_hash(item) }
+      else
+        value
       end
     end
 

--- a/lib/gem_docs/formatters/text.rb
+++ b/lib/gem_docs/formatters/text.rb
@@ -99,9 +99,11 @@ module GemDocs
         build_sections(
           metadata.empty? ? normalized_result.fetch(:path) : "#{normalized_result.fetch(:path)}  [#{metadata}]",
           normalized_result[:source_location],
+          knowledge_source_line(normalized_result[:knowledge_source]),
           nil,
           normalized_result[:signature],
           normalized_result[:docstring],
+          insights_section(normalized_result[:non_obvious_insights]),
           tag_sections(normalized_result[:tags]),
           aliases_section(normalized_result[:aliases])
         )
@@ -220,6 +222,35 @@ module GemDocs
         return if aliases.empty?
 
         "Aliases: #{aliases.join(', ')}"
+      end
+
+      def knowledge_source_line(knowledge_source)
+        return if knowledge_source.nil? || knowledge_source.to_s.empty?
+
+        "Knowledge source: #{knowledge_source}"
+      end
+
+      def insights_section(insights)
+        insights = Array(insights)
+        return if insights.empty?
+
+        [
+          "Non-obvious insights:",
+          *insights.map { |insight| format_insight(insight) }
+        ].join("\n")
+      end
+
+      def format_insight(insight)
+        case insight
+        when Hash
+          title = insight[:title] || insight["title"]
+          detail = insight[:detail] || insight["detail"]
+          return "  #{detail}" if title.nil? || title.to_s.empty?
+
+          [ "  - #{title}", detail ].compact.join(": ")
+        else
+          "  #{insight}"
+        end
       end
 
       def method_count_label(method_count)

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -171,6 +171,9 @@ module GemDocs
     def initialize: (?shell_runner: ^(Array[String]) -> command_response, ?cache: ArtifactCache?) -> void
     def load_gem: (String name, ?version: String?) -> LoadedGem
     def doc_source_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> doc_source
+    def artifact_invalidation_key_for: (String name, ?version: String?) -> String?
+    def source_artifacts_for: (String name, ?version: String?) -> Array[Hash[Symbol, untyped]]
+    def lookup_artifact_for: (String path, gem_name: String, ?version: String?) -> { kind: Symbol, payload: untyped }?
     def find_object: (String path, gem_name: String) -> Entry?
     def classes_for: (String gem_name) -> Array[Entry]
     def find_core_object: (String path) -> Entry?
@@ -185,8 +188,11 @@ module GemDocs
     def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> LoadedGem?
     def hydrate_cached_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem
     def persist_loaded_gem: (LoadedGem loaded_gem, invalidation_key: String?) -> bool?
+    def persist_source_artifacts: (LoadedGem loaded_gem, invalidation_key: String) -> Array[Entry]
+    def source_artifact_payload: (LoadedGem loaded_gem, Entry entry) -> Hash[String, untyped]
     def artifact_invalidation_key: (Gem::Specification spec) -> String
     def artifact_files_for: (Gem::Specification spec) -> Array[String]
+    def resolve_spec: (String name, ?version: String?) -> Gem::Specification?
     def load_yard_objects: (String yardoc) -> Array[Entry]
     def gem_description: (Gem::Specification spec) -> String?
     def gem_license: (Gem::Specification spec) -> String?
@@ -217,6 +223,7 @@ module GemDocs
     def yard_tags: (untyped object) -> Hash[Symbol, untyped]
     def normalize_yard_tag: (untyped tag) -> (Hash[Symbol, untyped] | String)?
     def yard_aliases: (untyped object) -> Array[String]
+    def stringify_hash: (untyped value) -> untyped
     def parse_rdoc_output: (String output) -> [String, String]
     def rdoc_kind_for: (String path, String signature) -> entry_kind
     def ri_list_command: (Gem::Specification spec) -> Array[String]
@@ -256,6 +263,11 @@ module GemDocs
       lookup_target: String,
       invalidation_key: String
     ) -> { kind: Symbol, payload: untyped }?
+    def source_artifacts: (
+      gem_name: String,
+      gem_version: String,
+      invalidation_key: String
+    ) -> Array[Hash[Symbol, untyped]]
     def write_artifact: (
       gem_name: String,
       gem_version: String,
@@ -277,6 +289,29 @@ module GemDocs
     def build_entry: (Hash[String, untyped] payload) -> DocRegistry::Entry
     def symbolize_hash: (untyped value) -> untyped
     def default_artifact_version: (Symbol artifact_kind) -> Integer
+    def compressed_usable?: (untyped payload) -> bool
+    def artifact_payload_digest: (untyped payload) -> String
+  end
+
+  module Compression
+    class Pipeline
+      PROMPT_VERSION: Integer
+      NON_OBVIOUS_KNOWLEDGE_DEFINITION: String
+      OUTPUT_SCHEMA: Hash[String, untyped]
+
+      def initialize: (
+        cache: ArtifactCache,
+        compressor: ^(gem: Hash[Symbol, String], source_artifact: Hash[Symbol, untyped], prompt: String, schema: Hash[String, untyped]) -> Hash[untyped, untyped],
+        ?doc_registry: DocRegistry
+      ) -> void
+      def compress_gem: (String gem_name, ?version: String?) -> Hash[Symbol, untyped]
+
+      private
+
+      def prompt_for: (DocRegistry::LoadedGem loaded_gem, Hash[Symbol, untyped] source_artifact) -> String
+      def normalize_payload: (Hash[untyped, untyped]? payload, source_artifact: Hash[Symbol, untyped]) -> Hash[String, untyped]
+      def stringify_insight: (untyped insight) -> Hash[String, untyped]
+    end
   end
 
   module Commands
@@ -346,6 +381,9 @@ module GemDocs
       def build_type_lines: (String title, untyped values) -> String?
       def build_example_lines: (untyped values) -> Array[String]?
       def aliases_section: (untyped aliases) -> String?
+      def knowledge_source_line: (untyped knowledge_source) -> String?
+      def insights_section: (untyped insights) -> String?
+      def format_insight: (untyped insight) -> String
     end
 
     module Context

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -189,6 +189,7 @@ module GemDocs
     def hydrate_cached_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem
     def persist_loaded_gem: (LoadedGem loaded_gem, invalidation_key: String?) -> bool?
     def persist_source_artifacts: (LoadedGem loaded_gem, invalidation_key: String) -> Array[Entry]
+    def ensure_source_artifacts_persisted: (LoadedGem loaded_gem, invalidation_key: String) -> Array[Hash[Symbol, untyped]]
     def source_artifact_payload: (LoadedGem loaded_gem, Entry entry) -> Hash[String, untyped]
     def artifact_invalidation_key: (Gem::Specification spec) -> String
     def artifact_files_for: (Gem::Specification spec) -> Array[String]
@@ -301,7 +302,7 @@ module GemDocs
 
       def initialize: (
         cache: ArtifactCache,
-        compressor: ^(gem: Hash[Symbol, String], source_artifact: Hash[Symbol, untyped], prompt: String, schema: Hash[String, untyped]) -> Hash[untyped, untyped],
+        compressor: ^(gem: Hash[Symbol, String], source_artifact: Hash[Symbol, untyped], prompt: String, schema: Hash[String, untyped]) -> Hash[untyped, untyped]?,
         ?doc_registry: DocRegistry
       ) -> void
       def compress_gem: (String gem_name, ?version: String?) -> Hash[Symbol, untyped]
@@ -310,6 +311,10 @@ module GemDocs
 
       def prompt_for: (DocRegistry::LoadedGem loaded_gem, Hash[Symbol, untyped] source_artifact) -> String
       def normalize_payload: (Hash[untyped, untyped]? payload, source_artifact: Hash[Symbol, untyped]) -> Hash[String, untyped]
+      def normalize_compressor_payload: (Hash[untyped, untyped]? payload) -> Hash[String, untyped]
+      def insufficient_payload: (String reason) -> Hash[String, untyped]
+      def validate_payload!: (Hash[String, untyped] payload) -> void
+      def validate_insight!: (Hash[String, untyped] insight) -> void
       def stringify_insight: (untyped insight) -> Hash[String, untyped]
     end
   end

--- a/spec/artifact_cache_spec.rb
+++ b/spec/artifact_cache_spec.rb
@@ -122,6 +122,106 @@ RSpec.describe GemDocs::ArtifactCache do
     end
   end
 
+  it "falls back to source artifacts when compressed knowledge is marked insufficient" do
+    Dir.mktmpdir do |tmpdir|
+      cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :source,
+        payload: { "docstring" => "Full source docs" },
+        invalidation_key: "digest-v1"
+      )
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :compressed,
+        payload: {
+          "status" => "insufficient",
+          "reason" => "The raw documentation is already obvious."
+        },
+        invalidation_key: "digest-v1"
+      )
+
+      expect(cache.fetch_with_fallback(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        invalidation_key: "digest-v1"
+      )).to eq(
+        {
+          kind: :source,
+          payload: { "docstring" => "Full source docs" }
+        }
+      )
+    end
+  end
+
+  it "lists source artifacts for offline compression by gem version and invalidation key" do
+    Dir.mktmpdir do |tmpdir|
+      cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget",
+        artifact_kind: :source,
+        payload: { "path" => "Demo::Widget", "docstring" => "Widget docs" },
+        invalidation_key: "digest-v1"
+      )
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :source,
+        payload: { "path" => "Demo::Widget#call", "docstring" => "Stale docs" },
+        invalidation_key: "digest-v0"
+      )
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: "Demo::Widget#call",
+        artifact_kind: :source,
+        payload: { "path" => "Demo::Widget#call", "docstring" => "Call docs" },
+        invalidation_key: "digest-v1"
+      )
+      cache.write_artifact(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        lookup_target: described_class::GEM_LOOKUP_TARGET,
+        artifact_kind: :source,
+        payload: { "name" => "demo" },
+        invalidation_key: "digest-v1"
+      )
+
+      expect(cache.source_artifacts(
+        gem_name: "demo",
+        gem_version: "1.0.0",
+        invalidation_key: "digest-v1"
+      )).to eq(
+        [
+          {
+            lookup_target: "Demo::Widget",
+            artifact_version: described_class::ARTIFACT_VERSIONS.fetch(:source),
+            invalidation_key: "digest-v1",
+            payload: { "path" => "Demo::Widget", "docstring" => "Widget docs" },
+            payload_digest: Digest::SHA256.hexdigest(JSON.generate({ "path" => "Demo::Widget", "docstring" => "Widget docs" }))
+          },
+          {
+            lookup_target: "Demo::Widget#call",
+            artifact_version: described_class::ARTIFACT_VERSIONS.fetch(:source),
+            invalidation_key: "digest-v1",
+            payload: { "path" => "Demo::Widget#call", "docstring" => "Call docs" },
+            payload_digest: Digest::SHA256.hexdigest(JSON.generate({ "path" => "Demo::Widget#call", "docstring" => "Call docs" }))
+          }
+        ]
+      )
+    end
+  end
+
   it "separates persisted artifacts by gem version" do
     Dir.mktmpdir do |tmpdir|
       cache = described_class.new(path: File.join(tmpdir, "artifacts.sqlite3"))

--- a/spec/commands/lookup_spec.rb
+++ b/spec/commands/lookup_spec.rb
@@ -196,6 +196,70 @@ RSpec.describe GemDocs::Commands::Lookup do
     end
   end
 
+  it "prefers compressed non-obvious knowledge and reports the knowledge source" do
+    with_yard_fixture_gem(name: "lookup_fixture", source: <<~RUBY) do
+      module LookupFixture
+        class Client
+          # Performs the request.
+          def call(input)
+          end
+        end
+      end
+    RUBY
+      Dir.mktmpdir do |tmpdir|
+        cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+        registry = GemDocs::DocRegistry.new(cache: cache)
+        invalidation_key = registry.artifact_invalidation_key_for("lookup_fixture")
+
+        registry.load_gem("lookup_fixture")
+        cache.write_artifact(
+          gem_name: "lookup_fixture",
+          gem_version: "0.1.0",
+          lookup_target: "LookupFixture::Client#call",
+          artifact_kind: :compressed,
+          payload: {
+            "status" => "ready",
+            "insights" => [
+              {
+                "title" => "Input is normalized",
+                "detail" => "Leading and trailing whitespace is stripped before dispatch."
+              }
+            ],
+            "source_artifact" => {
+              "lookup_target" => "LookupFixture::Client#call",
+              "artifact_kind" => "source",
+              "artifact_version" => GemDocs::ArtifactCache::ARTIFACT_VERSIONS.fetch(:source),
+              "invalidation_key" => invalidation_key,
+              "payload_digest" => "digest"
+            },
+            "prompt_version" => 1
+          },
+          invalidation_key: invalidation_key
+        )
+
+        allow(command).to receive(:doc_registry).and_return(registry)
+
+        status = command.call(
+          path: "LookupFixture::Client#call",
+          gem: "lookup_fixture",
+          format: "json"
+        )
+
+        expect(status).to eq(0)
+        expect(JSON.parse(stdout.string)).to include(
+          "path" => "LookupFixture::Client#call",
+          "knowledge_source" => "compressed",
+          "non_obvious_insights" => [
+            include(
+              "title" => "Input is normalized",
+              "detail" => "Leading and trailing whitespace is stripped before dispatch."
+            )
+          ]
+        )
+      end
+    end
+  end
+
   it "falls back to Ruby core ri lookups when no gem match exists" do
     registry = GemDocs::DocRegistry.new(
       shell_runner: lambda do |lookup_command|

--- a/spec/commands/lookup_spec.rb
+++ b/spec/commands/lookup_spec.rb
@@ -260,6 +260,55 @@ RSpec.describe GemDocs::Commands::Lookup do
     end
   end
 
+  it "falls back to source knowledge when compressed knowledge is marked insufficient" do
+    with_yard_fixture_gem(name: "lookup_fixture", source: <<~RUBY) do
+      module LookupFixture
+        class Client
+          # Performs the request.
+          def call(input)
+          end
+        end
+      end
+    RUBY
+      Dir.mktmpdir do |tmpdir|
+        cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+        registry = GemDocs::DocRegistry.new(cache: cache)
+        invalidation_key = registry.artifact_invalidation_key_for("lookup_fixture")
+
+        registry.load_gem("lookup_fixture")
+        cache.write_artifact(
+          gem_name: "lookup_fixture",
+          gem_version: "0.1.0",
+          lookup_target: "LookupFixture::Client#call",
+          artifact_kind: :compressed,
+          payload: {
+            "status" => "insufficient",
+            "reason" => "Only obvious API surface information was found.",
+            "insights" => []
+          },
+          invalidation_key: invalidation_key
+        )
+
+        allow(command).to receive(:doc_registry).and_return(registry)
+
+        status = command.call(
+          path: "LookupFixture::Client#call",
+          gem: "lookup_fixture",
+          format: "json"
+        )
+
+        expect(status).to eq(0)
+        payload = JSON.parse(stdout.string)
+
+        expect(payload).to include(
+          "path" => "LookupFixture::Client#call",
+          "knowledge_source" => "source"
+        )
+        expect(payload).not_to have_key("non_obvious_insights")
+      end
+    end
+  end
+
   it "falls back to Ruby core ri lookups when no gem match exists" do
     registry = GemDocs::DocRegistry.new(
       shell_runner: lambda do |lookup_command|

--- a/spec/compression/pipeline_spec.rb
+++ b/spec/compression/pipeline_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::Compression::Pipeline do
+  it "reads cached source artifacts and stores compressed knowledge with source linkage" do
+    with_yard_fixture_gem(name: "compression_fixture", source: <<~RUBY) do
+      module CompressionFixture
+        class Client
+          # Retries idempotent requests with exponential backoff.
+          #
+          # The middleware only retries safe failures and respects `Retry-After`.
+          def call
+          end
+        end
+      end
+    RUBY
+      Dir.mktmpdir do |tmpdir|
+        cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+        registry = GemDocs::DocRegistry.new(cache: cache)
+
+        registry.load_gem("compression_fixture")
+
+        pipeline = described_class.new(
+          cache: cache,
+          doc_registry: registry,
+          compressor: lambda do |gem:, source_artifact:, prompt:, schema:|
+            expect(gem).to include(name: "compression_fixture", version: "0.1.0")
+            expect(prompt).to include("non-obvious")
+            expect(schema.fetch("required")).to include("status", "insights")
+
+            {
+              "status" => "ready",
+              "insights" => [
+                {
+                  "title" => "Insight for #{source_artifact.fetch(:lookup_target)}",
+                  "detail" => "Backoff follows Retry-After instead of using only the local schedule.",
+                  "categories" => [ "behavior", "edge_case" ],
+                  "version_scope" => "0.1.0"
+                }
+              ]
+            }
+          end
+        )
+
+        result = pipeline.compress_gem("compression_fixture")
+        payload = cache.fetch_artifact(
+          gem_name: "compression_fixture",
+          gem_version: "0.1.0",
+          lookup_target: "CompressionFixture::Client#call",
+          artifact_kind: :compressed,
+          invalidation_key: registry.artifact_invalidation_key_for("compression_fixture")
+        )
+
+        expect(result).to eq(gem_name: "compression_fixture", gem_version: "0.1.0", compressed_count: 3)
+        expect(payload).to include(
+          "status" => "ready",
+          "insights" => [
+            include(
+              "title" => "Insight for CompressionFixture::Client#call",
+              "detail" => "Backoff follows Retry-After instead of using only the local schedule."
+            )
+          ],
+          "prompt_version" => GemDocs::Compression::Pipeline::PROMPT_VERSION
+        )
+        expect(payload.fetch("source_artifact")).to include(
+          "lookup_target" => "CompressionFixture::Client#call",
+          "artifact_kind" => "source",
+          "artifact_version" => GemDocs::ArtifactCache::ARTIFACT_VERSIONS.fetch(:source)
+        )
+        expect(payload.fetch("source_artifact").fetch("payload_digest")).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/compression/pipeline_spec.rb
+++ b/spec/compression/pipeline_spec.rb
@@ -74,4 +74,76 @@ RSpec.describe GemDocs::Compression::Pipeline do
       end
     end
   end
+
+  it "stores insufficient payloads when the compressor returns nothing" do
+    with_yard_fixture_gem(name: "compression_fixture", source: <<~RUBY) do
+      module CompressionFixture
+        class Client
+          # Retries idempotent requests with exponential backoff.
+          def call
+          end
+        end
+      end
+    RUBY
+      Dir.mktmpdir do |tmpdir|
+        cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+        registry = GemDocs::DocRegistry.new(cache: cache)
+
+        registry.load_gem("compression_fixture")
+
+        pipeline = described_class.new(
+          cache: cache,
+          doc_registry: registry,
+          compressor: lambda do |**_kwargs|
+            nil
+          end
+        )
+
+        pipeline.compress_gem("compression_fixture")
+        payload = cache.fetch_artifact(
+          gem_name: "compression_fixture",
+          gem_version: "0.1.0",
+          lookup_target: "CompressionFixture::Client#call",
+          artifact_kind: :compressed,
+          invalidation_key: registry.artifact_invalidation_key_for("compression_fixture")
+        )
+
+        expect(payload).to include(
+          "status" => "insufficient",
+          "reason" => "Compressor returned no structured payload",
+          "insights" => []
+        )
+      end
+    end
+  end
+
+  it "rejects malformed compressor payloads that do not match the documented schema" do
+    with_yard_fixture_gem(name: "compression_fixture", source: <<~RUBY) do
+      module CompressionFixture
+        class Client
+          # Retries idempotent requests with exponential backoff.
+          def call
+          end
+        end
+      end
+    RUBY
+      Dir.mktmpdir do |tmpdir|
+        cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+        registry = GemDocs::DocRegistry.new(cache: cache)
+
+        registry.load_gem("compression_fixture")
+
+        pipeline = described_class.new(
+          cache: cache,
+          doc_registry: registry,
+          compressor: lambda do |**_kwargs|
+            { "status" => "ready", "insights" => [ { "detail" => "Missing title" } ] }
+          end
+        )
+
+        expect { pipeline.compress_gem("compression_fixture") }
+          .to raise_error(ArgumentError, /title/)
+      end
+    end
+  end
 end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -108,6 +108,40 @@ RSpec.describe GemDocs::DocRegistry do
       end
     end
 
+    it "persists per-entry source artifacts for offline compression" do
+      with_source_fixture_gem("compression_source_fixture", source: <<~RUBY) do
+        module CompressionSourceFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        Dir.mktmpdir do |tmpdir|
+          cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+          registry = described_class.new(cache: cache)
+
+          registry.load_gem("compression_source_fixture")
+
+          artifacts = registry.source_artifacts_for("compression_source_fixture")
+
+          expect(artifacts.map { |artifact| artifact.fetch(:lookup_target) }).to include(
+            "CompressionSourceFixture",
+            "CompressionSourceFixture::Widget",
+            "CompressionSourceFixture::Widget#call"
+          )
+          expect(artifacts.find { |artifact| artifact.fetch(:lookup_target) == "CompressionSourceFixture::Widget#call" })
+            .to include(
+              payload: include(
+                "path" => "CompressionSourceFixture::Widget#call",
+                "signature" => "CompressionSourceFixture::Widget#call(input)",
+                "doc_source" => "source_only"
+              )
+            )
+        end
+      end
+    end
+
     it "invalidates persisted documentation artifacts when gem contents change" do
       with_source_fixture_gem("mutable_fixture", source: <<~RUBY) do |spec|
         module MutableFixture

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -142,6 +142,44 @@ RSpec.describe GemDocs::DocRegistry do
       end
     end
 
+    it "backfills missing per-entry source artifacts from cached gem snapshots" do
+      with_source_fixture_gem("compression_source_fixture", source: <<~RUBY) do
+        module CompressionSourceFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        Dir.mktmpdir do |tmpdir|
+          cache_path = File.join(tmpdir, "artifacts.sqlite3")
+          cache = GemDocs::ArtifactCache.new(path: cache_path)
+          initial_registry = described_class.new(cache: cache)
+
+          initial_registry.load_gem("compression_source_fixture")
+
+          SQLite3::Database.new(cache_path).tap do |database|
+            database.execute(
+              "DELETE FROM documentation_artifacts WHERE gem_name = ? AND lookup_target != ?",
+              "compression_source_fixture",
+              GemDocs::ArtifactCache::GEM_LOOKUP_TARGET
+            )
+          ensure
+            database.close
+          end
+
+          rebuilt_registry = described_class.new(cache: GemDocs::ArtifactCache.new(path: cache_path))
+          artifacts = rebuilt_registry.source_artifacts_for("compression_source_fixture")
+
+          expect(artifacts.map { |artifact| artifact.fetch(:lookup_target) }).to include(
+            "CompressionSourceFixture",
+            "CompressionSourceFixture::Widget",
+            "CompressionSourceFixture::Widget#call"
+          )
+        end
+      end
+    end
+
     it "invalidates persisted documentation artifacts when gem contents change" do
       with_source_fixture_gem("mutable_fixture", source: <<~RUBY) do |spec|
         module MutableFixture
@@ -246,7 +284,7 @@ RSpec.describe GemDocs::DocRegistry do
 
           case command.last
           when "-l"
-            { stdout: "RdocOnly::Widget\n", stderr: "", success: true }
+            { stdout: "RdocOnly::Widget\nRdocOnly::Widget#call\n", stderr: "", success: true }
           when "RdocOnly::Widget"
             { stdout: "class RdocOnly::Widget\n\nThe primary RDoc class.\n", stderr: "", success: true }
           when "RdocOnly::Widget#call"
@@ -262,7 +300,8 @@ RSpec.describe GemDocs::DocRegistry do
         object = registry.find_object("RdocOnly::Widget#call", gem_name: "rdoc_only")
 
         expect(loaded_gem.doc_source).to eq(:rdoc)
-        expect(commands.count { |command| command.last == "RdocOnly::Widget" }).to eq(0)
+        expect(commands.count { |command| command.last == "RdocOnly::Widget" }).to eq(1)
+        expect(commands.count { |command| command.last == "RdocOnly::Widget#call" }).to eq(1)
         expect(object&.doc_source).to eq(:rdoc)
         expect(object&.docstring).to include("Calls through ri.")
       end
@@ -279,7 +318,7 @@ RSpec.describe GemDocs::DocRegistry do
 
             case command.last
             when "-l"
-              { stdout: "RdocOnly::Widget\n", stderr: "", success: true }
+              { stdout: "RdocOnly::Widget\nRdocOnly::Widget#call\n", stderr: "", success: true }
             when "RdocOnly::Widget"
               { stdout: "class RdocOnly::Widget\n\nThe primary RDoc class.\n", stderr: "", success: true }
             when "RdocOnly::Widget#call"
@@ -307,6 +346,40 @@ RSpec.describe GemDocs::DocRegistry do
           expect(object&.docstring).to include("Calls through ri.")
           expect(commands.map(&:last)).to include("RdocOnly::Widget#call")
           expect(commands.map(&:last)).not_to include("-l")
+        end
+      end
+    end
+
+    it "persists hydrated ri object payloads for offline compression" do
+      stub_fixture_gem("rdoc_only", registry_class: described_class) do
+        Dir.mktmpdir do |tmpdir|
+          cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+
+          shell_runner = lambda do |command|
+            case command.last
+            when "-l"
+              { stdout: "RdocOnly::Widget\nRdocOnly::Widget#call\n", stderr: "", success: true }
+            when "RdocOnly::Widget"
+              { stdout: "class RdocOnly::Widget\n\nThe primary RDoc class.\n", stderr: "", success: true }
+            when "RdocOnly::Widget#call"
+              { stdout: "RdocOnly::Widget#call\n\nCalls through ri.\n", stderr: "", success: true }
+            else
+              { stdout: "", stderr: "Not found", success: false }
+            end
+          end
+
+          registry = described_class.new(shell_runner: shell_runner, cache: cache)
+
+          registry.load_gem("rdoc_only")
+          artifacts = registry.source_artifacts_for("rdoc_only")
+
+          expect(artifacts.find { |artifact| artifact.fetch(:lookup_target) == "RdocOnly::Widget#call" }).to include(
+            payload: include(
+              "doc_source" => "rdoc",
+              "signature" => "RdocOnly::Widget#call",
+              "docstring" => "Calls through ri."
+            )
+          )
         end
       end
     end

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -144,6 +144,32 @@ RSpec.describe GemDocs::Formatters::Text do
         "Aliases: Rack::Builder.compile"
       )
     end
+
+    it "renders compressed insight details even when a title is missing" do
+      formatter = described_class.new
+
+      output = formatter.lookup(
+        result: {
+          path: "Rack::Builder",
+          gem: "rack",
+          version: "3.1.0",
+          doc_source: :yard,
+          signature: "def build(app = nil)",
+          docstring: "Builds Rack applications",
+          knowledge_source: :compressed,
+          non_obvious_insights: [
+            { "detail" => "Builder freezes middleware order after map is evaluated." }
+          ],
+          tags: {},
+          aliases: []
+        }
+      )
+
+      expect(output).to include("Knowledge source: compressed")
+      expect(output).to include("Non-obvious insights:")
+      expect(output).to include("  Builder freezes middleware order after map is evaluated.")
+      expect(output).not_to include("  - :")
+    end
   end
 
   describe "#search" do


### PR DESCRIPTION
## Summary
- persist per-entry source artifacts so offline compression can read normalized lookup payloads from the cache DB
- add an offline compression pipeline and runtime lookup metadata for compressed vs raw fallback behavior
- document the prompt/schema and evaluation approach for non-obvious gem knowledge

Closes #31

## Test plan
- bundle exec rubocop -a
- bundle exec steep check
- bundle exec rspec