### PR TITLE
refactor: extract GemLoader source fallback boundary

### DIFF
--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -153,7 +153,7 @@ module GemDocs
         return cached_gem
       end
 
-      loaded_gem = @gem_loader.load(name, version: normalized_version, spec: spec) || build_loaded_gem(spec)
+      loaded_gem = build_loaded_gem(spec)
       @doc_sources[cache_key] = loaded_gem.doc_source
       persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
@@ -414,8 +414,7 @@ module GemDocs
           lazy_paths: rdoc_objects.map(&:path)
         )
       else
-        objects = load_source_objects(spec)
-        build_source_loaded_gem(spec, objects: objects, doc_source: objects.empty? ? :none : :source_only)
+        @gem_loader.load_fallback(spec)
       end
 
       loaded_gem

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -121,11 +121,19 @@ module GemDocs
       end
     end
 
-    def initialize(shell_runner: nil, cache: nil)
+    def initialize(shell_runner: nil, cache: nil, gem_loader: nil)
       @loaded_gems = {}
       @doc_sources = {}
       @shell_runner = shell_runner || method(:run_command)
       @cache = cache == false ? nil : (cache || GemDocs::ArtifactCache.default(root: Dir.pwd))
+      @gem_loader = gem_loader || GemLoader.new(
+        spec_resolver: self.class.method(:gem_spec_for),
+        doc_source_detector: method(:detect_doc_source),
+        source_loader: method(:load_source_objects),
+        loaded_gem_builder: lambda do |spec, objects, doc_source|
+          build_source_loaded_gem(spec, objects: objects, doc_source: doc_source)
+        end
+      )
     end
 
     def load_gem(name, version: nil)
@@ -134,13 +142,7 @@ module GemDocs
       return loaded_gem if loaded_gem
 
       normalized_version = normalize_version(version)
-
-      spec = if normalized_version.nil?
-        self.class.gem_spec_for(name)
-      else
-        self.class.gem_spec_for(name, version: normalized_version)
-      end
-      raise GemDocs::GemNotFound.new(name) unless spec
+      spec = @gem_loader.resolve_spec!(name, version: normalized_version)
 
       invalidation_key = safe_artifact_invalidation_key(spec)
       cached_gem = fetch_cached_loaded_gem(spec, invalidation_key: invalidation_key)
@@ -151,7 +153,7 @@ module GemDocs
         return cached_gem
       end
 
-      loaded_gem = build_loaded_gem(spec)
+      loaded_gem = @gem_loader.load(name, version: normalized_version, spec: spec) || build_loaded_gem(spec)
       @doc_sources[cache_key] = loaded_gem.doc_source
       persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
@@ -163,22 +165,15 @@ module GemDocs
       return loaded_gem.doc_source if loaded_gem
 
       normalized_version = normalize_version(version)
-      spec ||= if normalized_version.nil?
-        self.class.gem_spec_for(name)
-      else
-        self.class.gem_spec_for(name, version: normalized_version)
-      end
-      raise GemDocs::GemNotFound.new(name) unless spec
+      spec ||= @gem_loader.resolve_spec!(name, version: normalized_version)
 
       @doc_sources.fetch(cache_key) do
-        @doc_sources[cache_key] = detect_doc_source(spec)
+        @doc_sources[cache_key] = @gem_loader.detect_source(spec)
       end
     end
 
     def artifact_invalidation_key_for(name, version: nil)
-      spec = resolve_spec(name, version: version)
-      raise GemDocs::GemNotFound.new(name) unless spec
-
+      spec = @gem_loader.resolve_spec!(name, version: version)
       safe_artifact_invalidation_key(spec)
     end
 
@@ -383,10 +378,9 @@ module GemDocs
     end
 
     def resolve_spec(name, version: nil)
-      normalized_version = normalize_version(version)
-      return self.class.gem_spec_for(name) if normalized_version.nil?
-
-      self.class.gem_spec_for(name, version: normalized_version)
+      @gem_loader.resolve_spec!(name, version: version)
+    rescue GemDocs::GemNotFound
+      nil
     end
 
     def build_loaded_gem(spec)
@@ -421,21 +415,25 @@ module GemDocs
         )
       else
         objects = load_source_objects(spec)
-        LoadedGem.new(
-          name: spec.name,
-          version: spec.version.to_s,
-          summary: spec.summary,
-          description: gem_description(spec),
-          homepage: spec.homepage,
-          license: gem_license(spec),
-          path: spec.full_gem_path,
-          doc_source: objects.empty? ? :none : :source_only,
-          objects: objects,
-          entry_points: infer_entry_points(spec.name, objects, doc_source: objects.empty? ? :none : :source_only)
-        )
+        build_source_loaded_gem(spec, objects: objects, doc_source: objects.empty? ? :none : :source_only)
       end
 
       loaded_gem
+    end
+
+    def build_source_loaded_gem(spec, objects:, doc_source:)
+      LoadedGem.new(
+        name: spec.name,
+        version: spec.version.to_s,
+        summary: spec.summary,
+        description: gem_description(spec),
+        homepage: spec.homepage,
+        license: gem_license(spec),
+        path: spec.full_gem_path,
+        doc_source: doc_source,
+        objects: objects,
+        entry_points: infer_entry_points(spec.name, objects, doc_source: doc_source)
+      )
     end
 
     def load_yard_objects(yardoc)

--- a/lib/gem_docs/gem_loader.rb
+++ b/lib/gem_docs/gem_loader.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class GemLoader
+    def initialize(spec_resolver:, doc_source_detector:, source_loader:, loaded_gem_builder:)
+      @spec_resolver = spec_resolver
+      @doc_source_detector = doc_source_detector
+      @source_loader = source_loader
+      @loaded_gem_builder = loaded_gem_builder
+    end
+
+    def load(name, version: nil, spec: nil)
+      spec ||= resolve_spec!(name, version: version)
+      doc_source = detect_source(spec)
+      return unless doc_source == :source_only || doc_source == :none
+
+      # @type var objects: Array[GemDocs::DocRegistry::Entry]
+      objects = if doc_source == :source_only
+        @source_loader.call(spec)
+      else
+        []
+      end
+      @loaded_gem_builder.call(spec, objects, doc_source)
+    end
+
+    def detect_source(spec)
+      @doc_source_detector.call(spec)
+    end
+
+    def resolve_spec!(name, version: nil)
+      spec = if version.nil? || version.empty?
+        @spec_resolver.call(name)
+      else
+        @spec_resolver.call(name, version: version)
+      end
+      return spec if spec
+
+      raise GemDocs::GemNotFound.new(name)
+    end
+  end
+end

--- a/lib/gem_docs/gem_loader.rb
+++ b/lib/gem_docs/gem_loader.rb
@@ -14,17 +14,18 @@ module GemDocs
       doc_source = detect_source(spec)
       return unless doc_source == :source_only || doc_source == :none
 
-      # @type var objects: Array[GemDocs::DocRegistry::Entry]
-      objects = if doc_source == :source_only
-        @source_loader.call(spec)
-      else
-        []
-      end
-      @loaded_gem_builder.call(spec, objects, doc_source)
+      load_fallback(spec, doc_source: doc_source)
     end
 
     def detect_source(spec)
       @doc_source_detector.call(spec)
+    end
+
+    def load_fallback(spec, doc_source: nil)
+      # @type var objects: Array[GemDocs::DocRegistry::Entry]
+      objects = @source_loader.call(spec)
+      resolved_doc_source = doc_source || (objects.empty? ? :none : :source_only)
+      @loaded_gem_builder.call(spec, objects, resolved_doc_source)
     end
 
     def resolve_spec!(name, version: nil)

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -31,6 +31,18 @@ module GemDocs
   def self.config: (?root: String) -> Config
   def self.reset_config_cache!: -> void
 
+  class GemLoader
+    def initialize: (
+      spec_resolver: ^(String, ?version: String?) -> Gem::Specification?,
+      doc_source_detector: ^(Gem::Specification) -> doc_source,
+      source_loader: ^(Gem::Specification) -> Array[DocRegistry::Entry],
+      loaded_gem_builder: ^(Gem::Specification, Array[DocRegistry::Entry], doc_source) -> DocRegistry::LoadedGem
+    ) -> void
+    def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
+    def detect_source: (Gem::Specification spec) -> doc_source
+    def resolve_spec!: (String name, ?version: String?) -> Gem::Specification
+  end
+
   class Config
     FILE_NAME: String
     VALID_COLORS: Array[String]
@@ -168,7 +180,11 @@ module GemDocs
 
     def self.gem_spec_for: (String name, ?version: String?) -> Gem::Specification?
 
-    def initialize: (?shell_runner: ^(Array[String]) -> command_response, ?cache: ArtifactCache?) -> void
+    def initialize: (
+      ?shell_runner: ^(Array[String]) -> command_response,
+      ?cache: ArtifactCache?,
+      ?gem_loader: GemLoader?
+    ) -> void
     def load_gem: (String name, ?version: String?) -> LoadedGem
     def doc_source_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> doc_source
     def artifact_invalidation_key_for: (String name, ?version: String?) -> String?
@@ -184,6 +200,7 @@ module GemDocs
     def cache_key_for: (String name, String? version) -> (String | [String, String])
     def normalize_version: (String? version) -> String?
     def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
+    def build_source_loaded_gem: (Gem::Specification spec, objects: Array[Entry], doc_source: doc_source) -> LoadedGem
     def safe_artifact_invalidation_key: (Gem::Specification spec) -> String?
     def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> LoadedGem?
     def hydrate_cached_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -40,6 +40,7 @@ module GemDocs
     ) -> void
     def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
     def detect_source: (Gem::Specification spec) -> doc_source
+    def load_fallback: (Gem::Specification spec, ?doc_source: doc_source?) -> DocRegistry::LoadedGem
     def resolve_spec!: (String name, ?version: String?) -> Gem::Specification
   end
 

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -6,6 +6,24 @@ require "gem_docs"
 
 RSpec.describe GemDocs::DocRegistry do
   describe "#load_gem" do
+    it "uses the gem loader for the source-only fallback path" do
+      with_source_fixture_gem("source_only", source: "module SourceOnly; end\n") do |spec|
+        loaded_gem = instance_double(
+          GemDocs::DocRegistry::LoadedGem,
+          doc_source: :source_only,
+          name: "source_only",
+          version: "0.1.0"
+        )
+        gem_loader = instance_double(GemDocs::GemLoader)
+        allow(gem_loader).to receive(:resolve_spec!).with("source_only", version: nil).and_return(spec)
+        allow(gem_loader).to receive(:load).with("source_only", version: nil, spec: spec).and_return(loaded_gem)
+
+        registry = described_class.new(cache: false, gem_loader: gem_loader)
+
+        expect(registry.load_gem("source_only")).to equal(loaded_gem)
+      end
+    end
+
     it "loads the shared local YARD fixture through the shared helper" do
       stub_fixture_gem("yard", name: "yard_fixture", yard: true) do
         registry = described_class.new
@@ -468,6 +486,18 @@ RSpec.describe GemDocs::DocRegistry do
   end
 
   describe "#doc_source_for" do
+    it "uses the gem loader to detect no-doc gems" do
+      with_empty_fixture_gem("empty_fixture") do |spec|
+        gem_loader = instance_double(GemDocs::GemLoader)
+        allow(gem_loader).to receive(:resolve_spec!).with("empty_fixture", version: nil).and_return(spec)
+        allow(gem_loader).to receive(:detect_source).with(spec).and_return(:none)
+
+        registry = described_class.new(cache: false, gem_loader: gem_loader)
+
+        expect(registry.doc_source_for("empty_fixture")).to eq(:none)
+      end
+    end
+
     it "reuses cached versioned loads for doc source lookups" do
       Dir.mktmpdir do |tmpdir|
         gem_root = File.join(tmpdir, "versioned-gem")

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GemDocs::DocRegistry do
         )
         gem_loader = instance_double(GemDocs::GemLoader)
         allow(gem_loader).to receive(:resolve_spec!).with("source_only", version: nil).and_return(spec)
-        allow(gem_loader).to receive(:load).with("source_only", version: nil, spec: spec).and_return(loaded_gem)
+        allow(gem_loader).to receive(:load_fallback).with(spec).and_return(loaded_gem)
 
         registry = described_class.new(cache: false, gem_loader: gem_loader)
 
@@ -451,6 +451,29 @@ RSpec.describe GemDocs::DocRegistry do
         expect(loaded_gem.doc_source).to eq(:source_only)
         expect(registry.find_object("RiMissing::Widget#call", gem_name: "ri_missing")&.signature)
           .to eq("RiMissing::Widget#call()")
+      end
+    end
+
+    it "loads the ri index once for rdoc gems" do
+      stub_fixture_gem("rdoc_only", registry_class: described_class) do |spec|
+        commands = []
+
+        shell_runner = lambda do |command|
+          commands << command
+
+          case command.last
+          when "-l"
+            { stdout: "RdocOnly::Widget\n", stderr: "", success: true }
+          else
+            raise "unexpected command: #{command.inspect}"
+          end
+        end
+
+        registry = described_class.new(shell_runner: shell_runner, cache: false)
+        loaded_gem = registry.load_gem("rdoc_only")
+
+        expect(loaded_gem.doc_source).to eq(:rdoc)
+        expect(commands).to eq([ [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "-l" ] ])
       end
     end
 

--- a/spec/gem_loader_spec.rb
+++ b/spec/gem_loader_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::GemLoader do
+  describe "#resolve_spec!" do
+    it "returns the requested gem spec when it exists" do
+      with_source_fixture_gem("source_only", source: "module SourceOnly; end\n") do |spec|
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: ->(_resolved_spec) { raise "unused" },
+          source_loader: ->(_resolved_spec) { raise "unused" },
+          loaded_gem_builder: ->(_resolved_spec, _objects, _doc_source) { raise "unused" }
+        )
+
+        expect(loader.resolve_spec!("source_only")).to eq(spec)
+      end
+    end
+
+    it "raises GemDocs::GemNotFound when the gem cannot be resolved" do
+      loader = described_class.new(
+        spec_resolver: ->(_name, version: nil) { nil },
+        doc_source_detector: ->(_resolved_spec) { raise "unused" },
+        source_loader: ->(_resolved_spec) { raise "unused" },
+        loaded_gem_builder: ->(_resolved_spec, _objects, _doc_source) { raise "unused" }
+      )
+
+      expect { loader.resolve_spec!("missing-gem") }.to raise_error(GemDocs::GemNotFound)
+    end
+  end
+
+  describe "#detect_source" do
+    it "detects the source-only fallback path" do
+      with_source_fixture_gem("source_only", source: <<~RUBY) do |spec|
+        module SourceOnly
+          class Widget
+            def call
+            end
+          end
+        end
+      RUBY
+        registry = GemDocs::DocRegistry.new(cache: false)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: registry.method(:detect_doc_source),
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: ->(_resolved_spec, _objects, _doc_source) { raise "unused" }
+        )
+
+        expect(loader.detect_source(spec)).to eq(:source_only)
+      end
+    end
+
+    it "detects gems with no documentable objects" do
+      with_empty_fixture_gem("empty_fixture") do |spec|
+        registry = GemDocs::DocRegistry.new(cache: false)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: registry.method(:detect_doc_source),
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: ->(_resolved_spec, _objects, _doc_source) { raise "unused" }
+        )
+
+        expect(loader.detect_source(spec)).to eq(:none)
+      end
+    end
+  end
+
+  describe "#load" do
+    it "builds a loaded gem for source-only gems" do
+      with_source_fixture_gem("source_only", source: <<~RUBY) do
+        module SourceOnly
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        registry = GemDocs::DocRegistry.new(cache: false)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: registry.method(:detect_doc_source),
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end
+        )
+
+        loaded_gem = loader.load("source_only")
+
+        expect(loaded_gem.doc_source).to eq(:source_only)
+        expect(loaded_gem.objects.map(&:path)).to include("SourceOnly", "SourceOnly::Widget", "SourceOnly::Widget#call")
+      end
+    end
+
+    it "builds an empty loaded gem for gems with no documentable objects" do
+      with_empty_fixture_gem("empty_fixture") do
+        registry = GemDocs::DocRegistry.new(cache: false)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: registry.method(:detect_doc_source),
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end
+        )
+
+        loaded_gem = loader.load("empty_fixture")
+
+        expect(loaded_gem.doc_source).to eq(:none)
+        expect(loaded_gem.objects).to eq([])
+        expect(loaded_gem.entry_points).to eq([])
+      end
+    end
+  end
+end

--- a/spec/gem_loader_spec.rb
+++ b/spec/gem_loader_spec.rb
@@ -114,4 +114,32 @@ RSpec.describe GemDocs::GemLoader do
       end
     end
   end
+
+  describe "#load_fallback" do
+    it "builds fallback loaded gems without re-detecting the doc source" do
+      with_source_fixture_gem("source_only", source: <<~RUBY) do |spec|
+        module SourceOnly
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        registry = GemDocs::DocRegistry.new(cache: false)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: ->(_resolved_spec) { raise "unused" },
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end
+        )
+
+        loaded_gem = loader.load_fallback(spec)
+
+        expect(loaded_gem.doc_source).to eq(:source_only)
+        expect(loaded_gem.objects.map(&:path)).to include("SourceOnly", "SourceOnly::Widget", "SourceOnly::Widget#call")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- introduce `GemDocs::GemLoader` as the source-only / no-doc loading boundary
- route `DocRegistry#load_gem`, `#doc_source_for`, and spec resolution through the loader for this slice
- add loader specs plus facade delegation coverage and update RBS signatures

Closes #35

## Test plan
- bundle exec rubocop
- bundle exec steep check
- bundle exec rspec