### PR TITLE
feat: add YARD doc provider adapter

### DIFF
--- a/lib/gem_docs/doc_providers/yard.rb
+++ b/lib/gem_docs/doc_providers/yard.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "yard"
+
+module GemDocs
+  module DocProviders
+    class Yard
+      YARD_MUTEX = Mutex.new
+      private_constant :YARD_MUTEX
+
+      def initialize(loaded_gem_builder:)
+        @loaded_gem_builder = loaded_gem_builder
+      end
+
+      def available?(spec)
+        File.exist?(yardoc_path_for(spec))
+      end
+
+      def load(spec)
+        @loaded_gem_builder.call(spec, load_objects(yardoc_path_for(spec)), :yard)
+      end
+
+      private
+
+      def yardoc_path_for(spec)
+        File.join(spec.full_gem_path, ".yardoc")
+      end
+
+      def load_objects(yardoc)
+        YARD_MUTEX.synchronize do
+          previous_yardoc = YARD::Registry.yardoc_file
+          YARD::Registry.clear
+          YARD::Registry.load!(yardoc)
+
+          objects = [] # : Array[GemDocs::DocRegistry::Entry]
+          queue = YARD::Registry.root.children.reverse
+
+          until queue.empty?
+            object = queue.pop
+
+            case object
+            when YARD::CodeObjects::ClassObject, YARD::CodeObjects::ModuleObject
+              objects << build_namespace_entry(object)
+              queue.concat(object.constants(inherited: false).reverse)
+              queue.concat(object.meths(inherited: false).reverse)
+              queue.concat(object.children.grep(YARD::CodeObjects::NamespaceObject).reverse)
+            when YARD::CodeObjects::MethodObject
+              objects << build_method_entry(object)
+            when YARD::CodeObjects::ConstantObject
+              objects << build_constant_entry(object)
+            end
+          end
+
+          objects
+        ensure
+          YARD::Registry.clear
+          YARD::Registry.yardoc_file = previous_yardoc
+        end
+      rescue StandardError => e
+        raise GemDocs::RegistryError.new("Failed to load YARD registry: #{e.message}")
+      end
+
+      def build_namespace_entry(object)
+        GemDocs::DocRegistry::Entry.new(
+          path: object.path,
+          name: object.name.to_s,
+          kind: object.is_a?(YARD::CodeObjects::ClassObject) ? :class : :module,
+          visibility: object.visibility || :public,
+          docstring: object.docstring.to_s,
+          signature: object.path,
+          source_location: source_location_for(object),
+          superclass: superclass_for(object),
+          doc_source: :yard,
+          tags: tags_for(object),
+          aliases: aliases_for(object)
+        )
+      end
+
+      def build_method_entry(object)
+        GemDocs::DocRegistry::Entry.new(
+          path: object.path,
+          name: object.name.to_s,
+          kind: object.scope == :class ? :class_method : :instance_method,
+          visibility: object.visibility || :public,
+          docstring: object.docstring.to_s,
+          signature: object.signature || object.path,
+          source_location: source_location_for(object),
+          superclass: nil,
+          doc_source: :yard,
+          tags: tags_for(object),
+          aliases: aliases_for(object)
+        )
+      end
+
+      def build_constant_entry(object)
+        GemDocs::DocRegistry::Entry.new(
+          path: object.path,
+          name: object.name.to_s,
+          kind: :constant,
+          visibility: object.visibility || :public,
+          docstring: object.docstring.to_s,
+          signature: object.path,
+          source_location: source_location_for(object),
+          superclass: nil,
+          doc_source: :yard,
+          tags: tags_for(object),
+          aliases: aliases_for(object)
+        )
+      end
+
+      def source_location_for(object)
+        return unless object.file && object.line
+
+        "#{object.file}:#{object.line}"
+      end
+
+      def superclass_for(object)
+        return unless object.is_a?(YARD::CodeObjects::ClassObject)
+
+        superclass = object.superclass
+        return unless superclass
+
+        superclass.respond_to?(:path) ? superclass.path : superclass.to_s
+      end
+
+      def tags_for(object)
+        return {} unless object.respond_to?(:tags)
+
+        # @type var grouped_tags: Hash[Symbol, untyped]
+        grouped_tags = {}
+        object.tags.each do |tag|
+          normalized = normalize_tag(tag)
+          next if normalized.nil?
+
+          grouped_tags[tag.tag_name.to_sym] ||= []
+          grouped_tags[tag.tag_name.to_sym] << normalized
+        end
+
+        grouped_tags
+      end
+
+      def normalize_tag(tag)
+        return tag.text.to_s.strip if tag.tag_name == "example"
+
+        # @type var payload: Hash[Symbol, untyped]
+        payload = {}
+        payload[:name] = tag.name if tag.respond_to?(:name) && tag.name
+        payload[:types] = Array(tag.types).map do |type|
+          # @type var type: untyped
+          type.to_s
+        end if tag.respond_to?(:types)
+        payload[:text] = tag.text.to_s.strip
+        payload
+      end
+
+      def aliases_for(object)
+        return [] unless object.respond_to?(:aliases)
+
+        Array(object.aliases).filter_map do |alias_object|
+          # @type var alias_object: untyped
+          alias_object.respond_to?(:path) ? alias_object.path : alias_object.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/gem_docs/doc_providers/yard.rb
+++ b/lib/gem_docs/doc_providers/yard.rb
@@ -27,12 +27,13 @@ module GemDocs
       end
 
       def load_objects(yardoc)
+        # @type var objects: Array[GemDocs::DocRegistry::Entry]
+        objects = []
+
         YARD_MUTEX.synchronize do
           previous_yardoc = YARD::Registry.yardoc_file
           YARD::Registry.clear
           YARD::Registry.load!(yardoc)
-
-          objects = [] # : Array[GemDocs::DocRegistry::Entry]
           queue = YARD::Registry.root.children.reverse
 
           until queue.empty?

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -2,14 +2,10 @@
 
 require "open3"
 require "prism"
-require "yard"
 require "digest"
 
 module GemDocs
   class DocRegistry
-    YARD_MUTEX = Mutex.new
-    private_constant :YARD_MUTEX
-
     class Entry < Data.define(
       :path,
       :name,
@@ -126,13 +122,19 @@ module GemDocs
       @doc_sources = {}
       @shell_runner = shell_runner || method(:run_command)
       @cache = cache == false ? nil : (cache || GemDocs::ArtifactCache.default(root: Dir.pwd))
+      yard_provider = GemDocs::DocProviders::Yard.new(
+        loaded_gem_builder: lambda do |spec, objects, doc_source|
+          build_source_loaded_gem(spec, objects: objects, doc_source: doc_source)
+        end
+      )
       @gem_loader = gem_loader || GemLoader.new(
         spec_resolver: self.class.method(:gem_spec_for),
         doc_source_detector: method(:detect_doc_source),
         source_loader: method(:load_source_objects),
         loaded_gem_builder: lambda do |spec, objects, doc_source|
           build_source_loaded_gem(spec, objects: objects, doc_source: doc_source)
-        end
+        end,
+        yard_provider: yard_provider
       )
     end
 
@@ -153,7 +155,11 @@ module GemDocs
         return cached_gem
       end
 
-      loaded_gem = build_loaded_gem(spec)
+      loaded_gem = if @gem_loader.provider_available?(spec) || !File.directory?(spec.doc_dir)
+        @gem_loader.load(name, version: normalized_version, spec: spec) || build_loaded_gem(spec)
+      else
+        build_loaded_gem(spec)
+      end
       @doc_sources[cache_key] = loaded_gem.doc_source
       persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
@@ -232,7 +238,6 @@ module GemDocs
     private
 
     def detect_doc_source(spec)
-      return :yard if File.exist?(yardoc_path_for(spec))
       return :rdoc if rdoc_available?(spec)
       return :source_only if source_objects_available?(spec)
 
@@ -384,21 +389,7 @@ module GemDocs
     end
 
     def build_loaded_gem(spec)
-      loaded_gem = if File.exist?(yardoc_path_for(spec))
-        objects = load_yard_objects(yardoc_path_for(spec))
-        LoadedGem.new(
-          name: spec.name,
-          version: spec.version.to_s,
-          summary: spec.summary,
-          description: gem_description(spec),
-          homepage: spec.homepage,
-          license: gem_license(spec),
-          path: spec.full_gem_path,
-          doc_source: :yard,
-          objects: objects,
-          entry_points: infer_entry_points(spec.name, objects, doc_source: :yard)
-        )
-      elsif (rdoc_objects = load_rdoc_objects(spec))
+      loaded_gem = if (rdoc_objects = load_rdoc_objects(spec))
         LoadedGem.new(
           name: spec.name,
           version: spec.version.to_s,
@@ -433,40 +424,6 @@ module GemDocs
         objects: objects,
         entry_points: infer_entry_points(spec.name, objects, doc_source: doc_source)
       )
-    end
-
-    def load_yard_objects(yardoc)
-      YARD_MUTEX.synchronize do
-        previous_yardoc = YARD::Registry.yardoc_file
-        YARD::Registry.clear
-        YARD::Registry.load!(yardoc)
-
-        objects = []
-        queue = YARD::Registry.root.children.reverse
-
-        until queue.empty?
-          object = queue.pop
-
-          case object
-          when YARD::CodeObjects::ClassObject, YARD::CodeObjects::ModuleObject
-            objects << build_yard_namespace_entry(object)
-            queue.concat(object.constants(inherited: false).reverse)
-            queue.concat(object.meths(inherited: false).reverse)
-            queue.concat(object.children.grep(YARD::CodeObjects::NamespaceObject).reverse)
-          when YARD::CodeObjects::MethodObject
-            objects << build_yard_method_entry(object)
-          when YARD::CodeObjects::ConstantObject
-            objects << build_yard_constant_entry(object)
-          end
-        end
-
-        objects
-      ensure
-        YARD::Registry.clear
-        YARD::Registry.yardoc_file = previous_yardoc
-      end
-    rescue StandardError => e
-      raise GemDocs::RegistryError.new("Failed to load YARD registry: #{e.message}")
     end
 
     def gem_description(spec)
@@ -576,54 +533,6 @@ module GemDocs
         doc_source: :rdoc,
         tags: {},
         aliases: []
-      )
-    end
-
-    def build_yard_namespace_entry(object)
-      Entry.new(
-        path: object.path,
-        name: object.name.to_s,
-        kind: object.is_a?(YARD::CodeObjects::ClassObject) ? :class : :module,
-        visibility: object.visibility || :public,
-        docstring: object.docstring.to_s,
-        signature: object.path,
-        source_location: yard_source_location(object),
-        superclass: yard_superclass(object),
-        doc_source: :yard,
-        tags: yard_tags(object),
-        aliases: yard_aliases(object)
-      )
-    end
-
-    def build_yard_method_entry(object)
-      Entry.new(
-        path: object.path,
-        name: object.name.to_s,
-        kind: object.scope == :class ? :class_method : :instance_method,
-        visibility: object.visibility || :public,
-        docstring: object.docstring.to_s,
-        signature: object.signature || object.path,
-        source_location: yard_source_location(object),
-        superclass: nil,
-        doc_source: :yard,
-        tags: yard_tags(object),
-        aliases: yard_aliases(object)
-      )
-    end
-
-    def build_yard_constant_entry(object)
-      Entry.new(
-        path: object.path,
-        name: object.name.to_s,
-        kind: :constant,
-        visibility: object.visibility || :public,
-        docstring: object.docstring.to_s,
-        signature: object.path,
-        source_location: yard_source_location(object),
-        superclass: nil,
-        doc_source: :yard,
-        tags: yard_tags(object),
-        aliases: yard_aliases(object)
       )
     end
 
@@ -809,51 +718,6 @@ module GemDocs
 
     def format_source_location(file, line)
       "#{file}:#{line}"
-    end
-
-    def yard_source_location(object)
-      return unless object.file && object.line
-
-      format_source_location(object.file, object.line)
-    end
-
-    def yard_superclass(object)
-      return unless object.is_a?(YARD::CodeObjects::ClassObject)
-
-      superclass = object.superclass
-      return unless superclass
-
-      superclass.respond_to?(:path) ? superclass.path : superclass.to_s
-    end
-
-    def yard_tags(object)
-      return {} unless object.respond_to?(:tags)
-
-      object.tags.each_with_object({}) do |tag, grouped_tags|
-        normalized = normalize_yard_tag(tag)
-        next if normalized.nil?
-
-        grouped_tags[tag.tag_name.to_sym] ||= []
-        grouped_tags[tag.tag_name.to_sym] << normalized
-      end
-    end
-
-    def normalize_yard_tag(tag)
-      return tag.text.to_s.strip if tag.tag_name == "example"
-
-      payload = {}
-      payload[:name] = tag.name if tag.respond_to?(:name) && tag.name
-      payload[:types] = Array(tag.types).map(&:to_s) if tag.respond_to?(:types)
-      payload[:text] = tag.text.to_s.strip
-      payload
-    end
-
-    def yard_aliases(object)
-      return [] unless object.respond_to?(:aliases)
-
-      Array(object.aliases).filter_map do |alias_object|
-        alias_object.respond_to?(:path) ? alias_object.path : alias_object.to_s
-      end
     end
 
     def stringify_hash(value)

--- a/lib/gem_docs/gem_loader.rb
+++ b/lib/gem_docs/gem_loader.rb
@@ -13,7 +13,8 @@ module GemDocs
     def load(name, version: nil, spec: nil)
       spec ||= resolve_spec!(name, version: version)
       doc_source = detect_source(spec)
-      return @yard_provider.load(spec) if doc_source == :yard
+      return @yard_provider.load(spec) if doc_source == :yard && @yard_provider
+      return load_fallback(spec) if doc_source == :yard
       return unless doc_source == :source_only || doc_source == :none
 
       load_fallback(spec, doc_source: doc_source)

--- a/lib/gem_docs/gem_loader.rb
+++ b/lib/gem_docs/gem_loader.rb
@@ -2,23 +2,31 @@
 
 module GemDocs
   class GemLoader
-    def initialize(spec_resolver:, doc_source_detector:, source_loader:, loaded_gem_builder:)
+    def initialize(spec_resolver:, doc_source_detector:, source_loader:, loaded_gem_builder:, yard_provider: nil)
       @spec_resolver = spec_resolver
       @doc_source_detector = doc_source_detector
       @source_loader = source_loader
       @loaded_gem_builder = loaded_gem_builder
+      @yard_provider = yard_provider
     end
 
     def load(name, version: nil, spec: nil)
       spec ||= resolve_spec!(name, version: version)
       doc_source = detect_source(spec)
+      return @yard_provider.load(spec) if doc_source == :yard
       return unless doc_source == :source_only || doc_source == :none
 
       load_fallback(spec, doc_source: doc_source)
     end
 
     def detect_source(spec)
+      return :yard if @yard_provider&.available?(spec)
+
       @doc_source_detector.call(spec)
+    end
+
+    def provider_available?(spec)
+      !@yard_provider.nil? && @yard_provider.available?(spec)
     end
 
     def load_fallback(spec, doc_source: nil)

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -36,12 +36,39 @@ module GemDocs
       spec_resolver: ^(String, ?version: String?) -> Gem::Specification?,
       doc_source_detector: ^(Gem::Specification) -> doc_source,
       source_loader: ^(Gem::Specification) -> Array[DocRegistry::Entry],
-      loaded_gem_builder: ^(Gem::Specification, Array[DocRegistry::Entry], doc_source) -> DocRegistry::LoadedGem
+      loaded_gem_builder: ^(Gem::Specification, Array[DocRegistry::Entry], doc_source) -> DocRegistry::LoadedGem,
+      ?yard_provider: DocProviders::Yard?
     ) -> void
     def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
     def detect_source: (Gem::Specification spec) -> doc_source
+    def provider_available?: (Gem::Specification spec) -> bool
     def load_fallback: (Gem::Specification spec, ?doc_source: doc_source?) -> DocRegistry::LoadedGem
     def resolve_spec!: (String name, ?version: String?) -> Gem::Specification
+  end
+
+  module DocProviders
+    class Yard
+      YARD_MUTEX: Mutex
+
+      def initialize: (
+        loaded_gem_builder: ^(Gem::Specification, Array[DocRegistry::Entry], :yard) -> DocRegistry::LoadedGem
+      ) -> void
+      def available?: (Gem::Specification spec) -> bool
+      def load: (Gem::Specification spec) -> DocRegistry::LoadedGem
+
+      private
+
+      def yardoc_path_for: (Gem::Specification spec) -> String
+      def load_objects: (String yardoc) -> Array[DocRegistry::Entry]
+      def build_namespace_entry: (YARD::CodeObjects::NamespaceObject object) -> DocRegistry::Entry
+      def build_method_entry: (YARD::CodeObjects::MethodObject object) -> DocRegistry::Entry
+      def build_constant_entry: (YARD::CodeObjects::ConstantObject object) -> DocRegistry::Entry
+      def source_location_for: (YARD::CodeObjects::BaseObject object) -> String?
+      def superclass_for: (YARD::CodeObjects::NamespaceObject object) -> String?
+      def tags_for: (untyped object) -> Hash[Symbol, untyped]
+      def normalize_tag: (untyped tag) -> (Hash[Symbol, untyped] | String)?
+      def aliases_for: (untyped object) -> Array[String]
+    end
   end
 
   class Config
@@ -212,7 +239,6 @@ module GemDocs
     def artifact_invalidation_key: (Gem::Specification spec) -> String
     def artifact_files_for: (Gem::Specification spec) -> Array[String]
     def resolve_spec: (String name, ?version: String?) -> Gem::Specification?
-    def load_yard_objects: (String yardoc) -> Array[Entry]
     def gem_description: (Gem::Specification spec) -> String?
     def gem_license: (Gem::Specification spec) -> String?
     def infer_entry_points: (String gem_name, Array[Entry] objects, doc_source: doc_source) -> Array[String]
@@ -222,9 +248,6 @@ module GemDocs
     def rdoc_available?: (Gem::Specification spec) -> bool
     def build_rdoc_index_entry: (String name) -> Entry
     def load_rdoc_object: (Gem::Specification spec, String path) -> Entry?
-    def build_yard_namespace_entry: (YARD::CodeObjects::NamespaceObject object) -> Entry
-    def build_yard_method_entry: (YARD::CodeObjects::MethodObject object) -> Entry
-    def build_yard_constant_entry: (YARD::CodeObjects::ConstantObject object) -> Entry
     def load_source_objects: (Gem::Specification spec) -> Array[Entry]
     def source_objects_available?: (Gem::Specification spec) -> bool
     def ruby_files_for: (Gem::Specification spec) -> Array[String]
@@ -237,11 +260,6 @@ module GemDocs
     def join_constant_path: (String? namespace_path, String constant_path) -> String
     def resolve_constant_reference: (String? namespace_path, String? constant_path) -> String?
     def format_source_location: (String file, Integer line) -> String
-    def yard_source_location: (YARD::CodeObjects::BaseObject object) -> String?
-    def yard_superclass: (YARD::CodeObjects::NamespaceObject object) -> String?
-    def yard_tags: (untyped object) -> Hash[Symbol, untyped]
-    def normalize_yard_tag: (untyped tag) -> (Hash[Symbol, untyped] | String)?
-    def yard_aliases: (untyped object) -> Array[String]
     def stringify_hash: (untyped value) -> untyped
     def parse_rdoc_output: (String output) -> [String, String]
     def rdoc_kind_for: (String path, String signature) -> entry_kind

--- a/spec/doc_providers/yard_spec.rb
+++ b/spec/doc_providers/yard_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::DocProviders::Yard do
+  describe "#available?" do
+    it "detects gem-local .yardoc registries" do
+      with_yard_fixture_gem("yard_available", source: "module YardAvailable; end\n") do |spec|
+        expect(described_class.new(loaded_gem_builder: ->(*) { raise "unused" }).available?(spec)).to eq(true)
+      end
+    end
+  end
+
+  describe "#load" do
+    it "normalizes YARD objects into loaded gem entries" do
+      with_yard_fixture_gem("well_documented", source: <<~RUBY) do |spec|
+        module WellDocumented
+          class Widget
+            # Performs work.
+            #
+            # @param input [String]
+            # @return [String]
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        registry = GemDocs::DocRegistry.new(cache: false)
+        provider = described_class.new(
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end
+        )
+
+        loaded_gem = provider.load(spec)
+
+        expect(loaded_gem.doc_source).to eq(:yard)
+        expect(loaded_gem.entry_points).to include("WellDocumented::Widget#call")
+        expect(loaded_gem.objects.find { |object| object.path == "WellDocumented::Widget#call" })
+          .to have_attributes(
+            kind: :instance_method,
+            signature: "def call(input)",
+            docstring: "Performs work.",
+            doc_source: :yard,
+            tags: {
+              param: [ include(name: "input", types: [ "String" ]) ],
+              return: [ include(types: [ "String" ]) ]
+            }
+          )
+      end
+    end
+  end
+end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -16,11 +16,31 @@ RSpec.describe GemDocs::DocRegistry do
         )
         gem_loader = instance_double(GemDocs::GemLoader)
         allow(gem_loader).to receive(:resolve_spec!).with("source_only", version: nil).and_return(spec)
-        allow(gem_loader).to receive(:load_fallback).with(spec).and_return(loaded_gem)
+        allow(gem_loader).to receive(:provider_available?).with(spec).and_return(false)
+        allow(gem_loader).to receive(:load).with("source_only", version: nil, spec: spec).and_return(loaded_gem)
 
         registry = described_class.new(cache: false, gem_loader: gem_loader)
 
         expect(registry.load_gem("source_only")).to equal(loaded_gem)
+      end
+    end
+
+    it "uses the gem loader for the YARD path" do
+      with_yard_fixture_gem("well_documented", source: "module WellDocumented; end\n") do |spec|
+        loaded_gem = instance_double(
+          GemDocs::DocRegistry::LoadedGem,
+          doc_source: :yard,
+          name: "well_documented",
+          version: "0.1.0"
+        )
+        gem_loader = instance_double(GemDocs::GemLoader)
+        allow(gem_loader).to receive(:resolve_spec!).with("well_documented", version: nil).and_return(spec)
+        allow(gem_loader).to receive(:provider_available?).with(spec).and_return(true)
+        allow(gem_loader).to receive(:load).with("well_documented", version: nil, spec: spec).and_return(loaded_gem)
+
+        registry = described_class.new(cache: false, gem_loader: gem_loader)
+
+        expect(registry.load_gem("well_documented")).to equal(loaded_gem)
       end
     end
 

--- a/spec/gem_loader_spec.rb
+++ b/spec/gem_loader_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe GemDocs::GemLoader do
   end
 
   describe "#detect_source" do
+    it "detects the YARD path through the YARD provider" do
+      with_yard_fixture_gem("well_documented", source: "module WellDocumented; end\n") do |spec|
+        registry = GemDocs::DocRegistry.new(cache: false)
+        yard_provider = GemDocs::DocProviders::Yard.new(
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end
+        )
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: registry.method(:detect_doc_source),
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end,
+          yard_provider: yard_provider
+        )
+
+        expect(loader.detect_source(spec)).to eq(:yard)
+      end
+    end
+
     it "detects the source-only fallback path" do
       with_source_fixture_gem("source_only", source: <<~RUBY) do |spec|
         module SourceOnly
@@ -68,6 +90,44 @@ RSpec.describe GemDocs::GemLoader do
   end
 
   describe "#load" do
+    it "builds a loaded gem for YARD-backed gems through the YARD provider" do
+      with_yard_fixture_gem("well_documented", source: <<~RUBY) do
+        module WellDocumented
+          class Widget
+            # Performs work.
+            #
+            # @param input [String]
+            # @return [String]
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        registry = GemDocs::DocRegistry.new(cache: false)
+        yard_provider = GemDocs::DocProviders::Yard.new(
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end
+        )
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: registry.method(:detect_doc_source),
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end,
+          yard_provider: yard_provider
+        )
+
+        loaded_gem = loader.load("well_documented")
+
+        expect(loaded_gem.doc_source).to eq(:yard)
+        expect(loaded_gem.entry_points).to include("WellDocumented::Widget#call")
+        expect(loaded_gem.objects.find { |object| object.path == "WellDocumented::Widget#call" }&.docstring)
+          .to include("Performs work.")
+      end
+    end
+
     it "builds a loaded gem for source-only gems" do
       with_source_fixture_gem("source_only", source: <<~RUBY) do
         module SourceOnly

--- a/spec/gem_loader_spec.rb
+++ b/spec/gem_loader_spec.rb
@@ -128,6 +128,32 @@ RSpec.describe GemDocs::GemLoader do
       end
     end
 
+    it "falls back to source loading when the detector returns :yard without a provider" do
+      with_source_fixture_gem("source_only", source: <<~RUBY) do
+        module SourceOnly
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        registry = GemDocs::DocRegistry.new(cache: false)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: ->(_resolved_spec) { :yard },
+          source_loader: registry.method(:load_source_objects),
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source|
+            registry.send(:build_source_loaded_gem, resolved_spec, objects: objects, doc_source: doc_source)
+          end
+        )
+
+        loaded_gem = loader.load("source_only")
+
+        expect(loaded_gem.doc_source).to eq(:source_only)
+        expect(loaded_gem.objects.map(&:path)).to include("SourceOnly", "SourceOnly::Widget", "SourceOnly::Widget#call")
+      end
+    end
+
     it "builds a loaded gem for source-only gems" do
       with_source_fixture_gem("source_only", source: <<~RUBY) do
         module SourceOnly


### PR DESCRIPTION
## Summary
- add a dedicated `GemDocs::DocProviders::Yard` adapter for YARD probing, loading, traversal, and entry normalization
- route YARD-backed gem loading through `GemLoader` while keeping `DocRegistry` facade behavior and RDoc/source fallbacks intact
- cover the adapter and facade wiring with YARD-focused specs and updated loader/registry expectations

Closes #36

## Test plan
- bundle exec rubocop
- bundle exec steep check
- bundle exec rspec