### PR TITLE
feat: add rdoc provider adapter

### DIFF
--- a/lib/gem_docs/doc_providers/rdoc.rb
+++ b/lib/gem_docs/doc_providers/rdoc.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module GemDocs
+  module DocProviders
+    class Rdoc
+      def initialize(shell_runner:, loaded_gem_builder:)
+        @shell_runner = shell_runner
+        @loaded_gem_builder = loaded_gem_builder
+        # @type var index_names: Hash[String, Array[String]?]
+        index_names = {}
+        @index_names = index_names
+      end
+
+      def available?(spec)
+        !index_names_for(spec).nil?
+      end
+
+      def load(spec)
+        names = index_names_for(spec)
+        return if names.nil? || names.empty?
+
+        @loaded_gem_builder.call(
+          spec,
+          names.map { |name| build_index_entry(name) },
+          :rdoc,
+          dynamic_lookup: ->(path) { lookup(spec, path) },
+          lazy_paths: names
+        )
+      end
+
+      def lookup(spec, path)
+        response = run_shell(ri_command(spec, path))
+        return unless response[:success]
+
+        signature, docstring = parse_output(response[:stdout])
+        build_entry(path, signature, docstring)
+      end
+
+      def hydrate_loaded_gem(spec, loaded_gem)
+        @loaded_gem_builder.call(
+          spec,
+          loaded_gem.objects,
+          :rdoc,
+          dynamic_lookup: ->(path) { lookup(spec, path) },
+          lazy_paths: loaded_gem.objects.map(&:path)
+        )
+      end
+
+      private
+
+      def index_names_for(spec)
+        cache_key = spec.full_gem_path
+        return @index_names[cache_key] if @index_names.key?(cache_key)
+        return @index_names[cache_key] = nil unless File.directory?(spec.doc_dir)
+
+        response = run_shell(ri_list_command(spec))
+        return @index_names[cache_key] = nil if command_execution_failed?(response)
+
+        raise GemDocs::RegistryError.new("Failed to load ri registry: #{response[:stderr]}") unless response[:success]
+
+        names = response[:stdout].lines.map(&:strip).reject(&:empty?)
+        @index_names[cache_key] = names.empty? ? nil : names
+      end
+
+      def build_index_entry(name)
+        GemDocs::DocRegistry::Entry.new(
+          path: name,
+          name: name.split("::").last,
+          kind: :class,
+          visibility: :public,
+          docstring: "",
+          signature: name,
+          source_location: nil,
+          superclass: nil,
+          doc_source: :rdoc,
+          tags: {},
+          aliases: []
+        )
+      end
+
+      def build_entry(path, signature, docstring)
+        GemDocs::DocRegistry::Entry.new(
+          path: path,
+          name: path.split(/[#.]/).last,
+          kind: kind_for(path, signature),
+          visibility: :public,
+          docstring: docstring,
+          signature: signature.empty? ? path : signature,
+          source_location: nil,
+          superclass: nil,
+          doc_source: :rdoc,
+          tags: {},
+          aliases: []
+        )
+      end
+
+      def parse_output(output)
+        lines = output.lines.map(&:rstrip)
+        signature = lines.first.to_s.strip
+        separator_index = lines.index("")
+        doc_lines = if separator_index
+          lines[(separator_index + 1)..]
+        else
+          lines[1..]
+        end
+
+        [ signature, Array(doc_lines).join("\n").strip ]
+      end
+
+      def kind_for(path, signature)
+        return :instance_method if path.include?("#")
+        return :class_method if path.match?(/\.[A-Za-z_]/)
+        return :constant if path.split("::").last == path.split("::").last.upcase
+        return :module if signature.start_with?("module ")
+
+        :class
+      end
+
+      def ri_list_command(spec)
+        [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "-l" ]
+      end
+
+      def ri_command(spec, *arguments)
+        [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "--", *arguments ]
+      end
+
+      def run_shell(command)
+        @shell_runner.call(command)
+      rescue SystemCallError => e
+        { stdout: "", stderr: e.message, success: false, error: e }
+      end
+
+      def command_execution_failed?(response)
+        response[:error].is_a?(SystemCallError)
+      end
+    end
+  end
+end

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -122,19 +122,33 @@ module GemDocs
       @doc_sources = {}
       @shell_runner = shell_runner || method(:run_command)
       @cache = cache == false ? nil : (cache || GemDocs::ArtifactCache.default(root: Dir.pwd))
+      loaded_gem_builder = lambda do |spec, objects, doc_source, dynamic_lookup: nil, lazy_paths: []|
+        build_loaded_gem(
+          spec,
+          objects: objects,
+          doc_source: doc_source,
+          dynamic_lookup: dynamic_lookup,
+          lazy_paths: lazy_paths
+        )
+      end
       yard_provider = GemDocs::DocProviders::Yard.new(
         loaded_gem_builder: lambda do |spec, objects, doc_source|
-          build_source_loaded_gem(spec, objects: objects, doc_source: doc_source)
+          loaded_gem_builder.call(spec, objects, doc_source)
         end
+      )
+      @rdoc_provider = GemDocs::DocProviders::Rdoc.new(
+        shell_runner: ->(command) { run_shell(*command) },
+        loaded_gem_builder: loaded_gem_builder
       )
       @gem_loader = gem_loader || GemLoader.new(
         spec_resolver: self.class.method(:gem_spec_for),
         doc_source_detector: method(:detect_doc_source),
         source_loader: method(:load_source_objects),
         loaded_gem_builder: lambda do |spec, objects, doc_source|
-          build_source_loaded_gem(spec, objects: objects, doc_source: doc_source)
+          loaded_gem_builder.call(spec, objects, doc_source)
         end,
-        yard_provider: yard_provider
+        yard_provider: yard_provider,
+        rdoc_provider: @rdoc_provider
       )
     end
 
@@ -155,11 +169,8 @@ module GemDocs
         return cached_gem
       end
 
-      loaded_gem = if @gem_loader.provider_available?(spec) || !File.directory?(spec.doc_dir)
-        @gem_loader.load(name, version: normalized_version, spec: spec) || build_loaded_gem(spec)
-      else
-        build_loaded_gem(spec)
-      end
+      loaded_gem = @gem_loader.load(name, version: normalized_version, spec: spec) ||
+        build_loaded_gem(spec, objects: [], doc_source: :none)
       @doc_sources[cache_key] = loaded_gem.doc_source
       persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
@@ -238,7 +249,7 @@ module GemDocs
     private
 
     def detect_doc_source(spec)
-      return :rdoc if rdoc_available?(spec)
+      return :rdoc if @rdoc_provider.available?(spec)
       return :source_only if source_objects_available?(spec)
 
       :none
@@ -353,20 +364,7 @@ module GemDocs
     def hydrate_cached_loaded_gem(spec, loaded_gem)
       return loaded_gem unless loaded_gem.doc_source == :rdoc
 
-      LoadedGem.new(
-        name: loaded_gem.name,
-        version: loaded_gem.version,
-        summary: loaded_gem.summary,
-        description: loaded_gem.description,
-        homepage: loaded_gem.homepage,
-        license: loaded_gem.license,
-        path: loaded_gem.path,
-        doc_source: loaded_gem.doc_source,
-        objects: loaded_gem.objects,
-        entry_points: loaded_gem.entry_points,
-        dynamic_lookup: ->(path) { load_rdoc_object(spec, path) },
-        lazy_paths: loaded_gem.objects.map(&:path)
-      )
+      @rdoc_provider.hydrate_loaded_gem(spec, loaded_gem)
     end
 
     def cache_key_for(name, version)
@@ -388,30 +386,7 @@ module GemDocs
       nil
     end
 
-    def build_loaded_gem(spec)
-      loaded_gem = if (rdoc_objects = load_rdoc_objects(spec))
-        LoadedGem.new(
-          name: spec.name,
-          version: spec.version.to_s,
-          summary: spec.summary,
-          description: gem_description(spec),
-          homepage: spec.homepage,
-          license: gem_license(spec),
-          path: spec.full_gem_path,
-          doc_source: :rdoc,
-          objects: rdoc_objects,
-          entry_points: infer_entry_points(spec.name, rdoc_objects, doc_source: :rdoc),
-          dynamic_lookup: ->(path) { load_rdoc_object(spec, path) },
-          lazy_paths: rdoc_objects.map(&:path)
-        )
-      else
-        @gem_loader.load_fallback(spec)
-      end
-
-      loaded_gem
-    end
-
-    def build_source_loaded_gem(spec, objects:, doc_source:)
+    def build_loaded_gem(spec, objects:, doc_source:, dynamic_lookup: nil, lazy_paths: [])
       LoadedGem.new(
         name: spec.name,
         version: spec.version.to_s,
@@ -422,8 +397,14 @@ module GemDocs
         path: spec.full_gem_path,
         doc_source: doc_source,
         objects: objects,
-        entry_points: infer_entry_points(spec.name, objects, doc_source: doc_source)
+        entry_points: infer_entry_points(spec.name, objects, doc_source: doc_source),
+        dynamic_lookup: dynamic_lookup,
+        lazy_paths: lazy_paths
       )
+    end
+
+    def build_source_loaded_gem(spec, objects:, doc_source:)
+      build_loaded_gem(spec, objects: objects, doc_source: doc_source)
     end
 
     def gem_description(spec)
@@ -469,71 +450,8 @@ module GemDocs
         classes.first
     end
 
-    def load_rdoc_objects(spec)
-      return unless File.directory?(spec.doc_dir)
-
-      response = run_shell(*ri_list_command(spec))
-      return if command_execution_failed?(response)
-
-      raise GemDocs::RegistryError.new("Failed to load ri registry: #{response[:stderr]}") unless response[:success]
-
-      names = response[:stdout].lines.map(&:strip).reject(&:empty?)
-      return if names.empty?
-
-      names.map do |name|
-        build_rdoc_index_entry(name)
-      end
-    end
-
     def yardoc_path_for(spec)
       File.join(spec.full_gem_path, ".yardoc")
-    end
-
-    def rdoc_available?(spec)
-      return false unless File.directory?(spec.doc_dir)
-
-      response = run_shell(*ri_list_command(spec))
-      return false if command_execution_failed?(response)
-
-      raise GemDocs::RegistryError.new("Failed to load ri registry: #{response[:stderr]}") unless response[:success]
-
-      response[:stdout].each_line.any? { |line| !line.strip.empty? }
-    end
-
-    def build_rdoc_index_entry(name)
-      Entry.new(
-        path: name,
-        name: name.split("::").last,
-        kind: :class,
-        visibility: :public,
-        docstring: "",
-        signature: name,
-        source_location: nil,
-        superclass: nil,
-        doc_source: :rdoc,
-        tags: {},
-        aliases: []
-      )
-    end
-
-    def load_rdoc_object(spec, path)
-      response = run_shell(*ri_command(spec, path))
-      return unless response[:success]
-
-      signature, docstring = parse_rdoc_output(response[:stdout])
-      Entry.new(
-        path: path,
-        name: path.split(/[#.]/).last,
-        kind: rdoc_kind_for(path, signature),
-        visibility: :public,
-        docstring: docstring,
-        signature: signature.empty? ? path : signature,
-        source_location: nil,
-        superclass: nil,
-        doc_source: :rdoc,
-        tags: {},
-        aliases: []
-      )
     end
 
     def load_source_objects(spec)
@@ -755,14 +673,6 @@ module GemDocs
       :class
     end
 
-    def ri_list_command(spec)
-      [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "-l" ]
-    end
-
-    def ri_command(spec, *arguments)
-      [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "--", *arguments ]
-    end
-
     def ri_core_command(*arguments)
       [ "ri", "--no-pager", "--", *arguments ]
     end
@@ -778,10 +688,6 @@ module GemDocs
       { stdout: stdout, stderr: stderr, success: status.success? }
     rescue SystemCallError => e
       { stdout: "", stderr: e.message, success: false, error: e }
-    end
-
-    def command_execution_failed?(response)
-      response[:error].is_a?(SystemCallError)
     end
 
     def push_children(stack, node, namespace_path, class_method_context = false)

--- a/lib/gem_docs/gem_loader.rb
+++ b/lib/gem_docs/gem_loader.rb
@@ -2,19 +2,28 @@
 
 module GemDocs
   class GemLoader
-    def initialize(spec_resolver:, doc_source_detector:, source_loader:, loaded_gem_builder:, yard_provider: nil)
+    def initialize(
+      spec_resolver:,
+      doc_source_detector:,
+      source_loader:,
+      loaded_gem_builder:,
+      yard_provider: nil,
+      rdoc_provider: nil
+    )
       @spec_resolver = spec_resolver
       @doc_source_detector = doc_source_detector
       @source_loader = source_loader
       @loaded_gem_builder = loaded_gem_builder
       @yard_provider = yard_provider
+      @rdoc_provider = rdoc_provider
     end
 
     def load(name, version: nil, spec: nil)
       spec ||= resolve_spec!(name, version: version)
       doc_source = detect_source(spec)
       return @yard_provider.load(spec) if doc_source == :yard && @yard_provider
-      return load_fallback(spec) if doc_source == :yard
+      return @rdoc_provider.load(spec) if doc_source == :rdoc && @rdoc_provider
+      return load_fallback(spec) if [ :yard, :rdoc ].include?(doc_source)
       return unless doc_source == :source_only || doc_source == :none
 
       load_fallback(spec, doc_source: doc_source)
@@ -22,12 +31,13 @@ module GemDocs
 
     def detect_source(spec)
       return :yard if @yard_provider&.available?(spec)
+      return :rdoc if @rdoc_provider&.available?(spec)
 
       @doc_source_detector.call(spec)
     end
 
     def provider_available?(spec)
-      !@yard_provider.nil? && @yard_provider.available?(spec)
+      @yard_provider&.available?(spec) || @rdoc_provider&.available?(spec) || false
     end
 
     def load_fallback(spec, doc_source: nil)

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -37,7 +37,8 @@ module GemDocs
       doc_source_detector: ^(Gem::Specification) -> doc_source,
       source_loader: ^(Gem::Specification) -> Array[DocRegistry::Entry],
       loaded_gem_builder: ^(Gem::Specification, Array[DocRegistry::Entry], doc_source) -> DocRegistry::LoadedGem,
-      ?yard_provider: DocProviders::Yard?
+      ?yard_provider: DocProviders::Yard?,
+      ?rdoc_provider: DocProviders::Rdoc?
     ) -> void
     def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
     def detect_source: (Gem::Specification spec) -> doc_source
@@ -47,6 +48,35 @@ module GemDocs
   end
 
   module DocProviders
+    class Rdoc
+      def initialize: (
+        shell_runner: ^(Array[String]) -> command_response,
+        loaded_gem_builder: ^(
+          Gem::Specification,
+          Array[DocRegistry::Entry],
+          :rdoc,
+          dynamic_lookup: ^(String) -> DocRegistry::Entry?,
+          lazy_paths: Array[String]
+        ) -> DocRegistry::LoadedGem
+      ) -> void
+      def available?: (Gem::Specification spec) -> bool
+      def load: (Gem::Specification spec) -> DocRegistry::LoadedGem?
+      def lookup: (Gem::Specification spec, String path) -> DocRegistry::Entry?
+      def hydrate_loaded_gem: (Gem::Specification spec, DocRegistry::LoadedGem loaded_gem) -> DocRegistry::LoadedGem
+
+      private
+
+      def index_names_for: (Gem::Specification spec) -> Array[String]?
+      def build_index_entry: (String name) -> DocRegistry::Entry
+      def build_entry: (String path, String signature, String docstring) -> DocRegistry::Entry
+      def parse_output: (String output) -> [String, String]
+      def kind_for: (String path, String signature) -> entry_kind
+      def ri_list_command: (Gem::Specification spec) -> Array[String]
+      def ri_command: (Gem::Specification spec, *String arguments) -> Array[String]
+      def run_shell: (Array[String] command) -> command_response
+      def command_execution_failed?: (command_response response) -> bool
+    end
+
     class Yard
       YARD_MUTEX: Mutex
 
@@ -227,7 +257,13 @@ module GemDocs
     def detect_doc_source: (Gem::Specification spec) -> doc_source
     def cache_key_for: (String name, String? version) -> (String | [String, String])
     def normalize_version: (String? version) -> String?
-    def build_loaded_gem: (Gem::Specification spec) -> LoadedGem
+    def build_loaded_gem: (
+      Gem::Specification spec,
+      objects: Array[Entry],
+      doc_source: doc_source,
+      ?dynamic_lookup: ^(String) -> Entry?,
+      ?lazy_paths: Array[String]
+    ) -> LoadedGem
     def build_source_loaded_gem: (Gem::Specification spec, objects: Array[Entry], doc_source: doc_source) -> LoadedGem
     def safe_artifact_invalidation_key: (Gem::Specification spec) -> String?
     def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> LoadedGem?
@@ -243,11 +279,7 @@ module GemDocs
     def gem_license: (Gem::Specification spec) -> String?
     def infer_entry_points: (String gem_name, Array[Entry] objects, doc_source: doc_source) -> Array[String]
     def select_primary_class: (Array[Entry] classes, String gem_name) -> Entry?
-    def load_rdoc_objects: (Gem::Specification spec) -> Array[Entry]?
     def yardoc_path_for: (Gem::Specification spec) -> String
-    def rdoc_available?: (Gem::Specification spec) -> bool
-    def build_rdoc_index_entry: (String name) -> Entry
-    def load_rdoc_object: (Gem::Specification spec, String path) -> Entry?
     def load_source_objects: (Gem::Specification spec) -> Array[Entry]
     def source_objects_available?: (Gem::Specification spec) -> bool
     def ruby_files_for: (Gem::Specification spec) -> Array[String]
@@ -263,12 +295,9 @@ module GemDocs
     def stringify_hash: (untyped value) -> untyped
     def parse_rdoc_output: (String output) -> [String, String]
     def rdoc_kind_for: (String path, String signature) -> entry_kind
-    def ri_list_command: (Gem::Specification spec) -> Array[String]
-    def ri_command: (Gem::Specification spec, *String arguments) -> Array[String]
     def ri_core_command: (*String arguments) -> Array[String]
     def run_shell: (*String command) -> command_response
     def run_command: (Array[String] command) -> command_response
-    def command_execution_failed?: (command_response response) -> bool
     def push_children: (Array[[Prism::Node, String?, bool]] stack, Prism::Node node, String? namespace_path, ?bool class_method_context) -> Array[[Prism::Node, String?, bool]]?
     def find_in_ancestor_chain: (LoadedGem loaded_gem, String path) -> Entry?
   end

--- a/spec/doc_providers/rdoc_spec.rb
+++ b/spec/doc_providers/rdoc_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::DocProviders::Rdoc do
+  describe "#available?" do
+    it "returns false when ri cannot be executed" do
+      with_source_fixture_gem("ri_missing", source: "module RiMissing; end\n") do |spec|
+        FileUtils.mkdir_p(spec.doc_dir)
+        provider = described_class.new(
+          shell_runner: lambda do |_command|
+            raise Errno::ENOENT, "ri"
+          end,
+          loaded_gem_builder: ->(*) { raise "unused" }
+        )
+
+        expect(provider.available?(spec)).to eq(false)
+      end
+    end
+  end
+
+  describe "#load" do
+    it "loads the ri index and lazily hydrates objects on demand" do
+      stub_fixture_gem("rdoc_only", registry_class: GemDocs::DocRegistry) do |spec|
+        commands = []
+        provider = described_class.new(
+          shell_runner: lambda do |command|
+            commands << command
+
+            case command.last
+            when "-l"
+              { stdout: "RdocOnly::Widget\nRdocOnly::Widget#call\n", stderr: "", success: true }
+            when "RdocOnly::Widget#call"
+              { stdout: "RdocOnly::Widget#call\n\nCalls through ri.\n", stderr: "", success: true }
+            else
+              { stdout: "class RdocOnly::Widget\n\nThe primary RDoc class.\n", stderr: "", success: true }
+            end
+          end,
+          loaded_gem_builder: lambda do |resolved_spec, objects, doc_source, dynamic_lookup: nil, lazy_paths: []|
+            GemDocs::DocRegistry::LoadedGem.new(
+              name: resolved_spec.name,
+              version: resolved_spec.version.to_s,
+              summary: resolved_spec.summary,
+              path: resolved_spec.full_gem_path,
+              doc_source: doc_source,
+              objects: objects,
+              dynamic_lookup: dynamic_lookup,
+              lazy_paths: lazy_paths
+            )
+          end
+        )
+
+        loaded_gem = provider.load(spec)
+
+        expect(loaded_gem.doc_source).to eq(:rdoc)
+        expect(loaded_gem.find("RdocOnly::Widget#call")).to have_attributes(
+          path: "RdocOnly::Widget#call",
+          doc_source: :rdoc,
+          docstring: "Calls through ri."
+        )
+        expect(commands.map(&:last)).to eq([ "-l", "RdocOnly::Widget#call" ])
+      end
+    end
+  end
+
+  describe "#lookup" do
+    it "passes lookup targets after the end-of-options marker" do
+      stub_fixture_gem("rdoc_only", registry_class: GemDocs::DocRegistry) do |spec|
+        commands = []
+        provider = described_class.new(
+          shell_runner: lambda do |command|
+            commands << command
+            { stdout: "RdocOnly::--\n\nFlag-like target.\n", stderr: "", success: true }
+          end,
+          loaded_gem_builder: ->(*) { raise "unused" }
+        )
+
+        provider.lookup(spec, "RdocOnly::--")
+
+        expect(commands).to eq([
+          [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "--", "RdocOnly::--" ]
+        ])
+      end
+    end
+  end
+end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -345,6 +345,34 @@ RSpec.describe GemDocs::DocRegistry do
       end
     end
 
+    it "keeps the end-of-options safeguard for lazy ri lookups" do
+      stub_fixture_gem("rdoc_only", registry_class: described_class) do |spec|
+        commands = []
+
+        shell_runner = lambda do |command|
+          commands << command
+
+          case command.last
+          when "-l"
+            { stdout: "RdocOnly::--\n", stderr: "", success: true }
+          when "RdocOnly::--"
+            { stdout: "RdocOnly::--\n\nFlag-like target.\n", stderr: "", success: true }
+          else
+            raise "unexpected command: #{command.inspect}"
+          end
+        end
+
+        registry = described_class.new(shell_runner: shell_runner, cache: false)
+
+        object = registry.find_object("RdocOnly::--", gem_name: "rdoc_only")
+
+        expect(object&.docstring).to eq("Flag-like target.")
+        expect(commands).to include(
+          [ "ri", "--no-pager", "--no-standard-docs", "-d", spec.doc_dir, "--", "RdocOnly::--" ]
+        )
+      end
+    end
+
     it "rebuilds cached rdoc gems with lazy ri lookups across registry instances" do
       stub_fixture_gem("rdoc_only", registry_class: described_class) do
         Dir.mktmpdir do |tmpdir|

--- a/spec/gem_loader_spec.rb
+++ b/spec/gem_loader_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe GemDocs::GemLoader do
       end
     end
 
+    it "detects the RDoc path through the RDoc provider" do
+      with_source_fixture_gem("rdoc_available", source: "module RdocAvailable; end\n") do |spec|
+        yard_provider = instance_double(GemDocs::DocProviders::Yard, available?: false)
+        rdoc_provider = instance_double(GemDocs::DocProviders::Rdoc, available?: true)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: ->(_resolved_spec) { :source_only },
+          source_loader: ->(_resolved_spec) { raise "unused" },
+          loaded_gem_builder: ->(_resolved_spec, _objects, _doc_source) { raise "unused" },
+          yard_provider: yard_provider,
+          rdoc_provider: rdoc_provider
+        )
+
+        expect(loader.detect_source(spec)).to eq(:rdoc)
+      end
+    end
+
     it "detects gems with no documentable objects" do
       with_empty_fixture_gem("empty_fixture") do |spec|
         registry = GemDocs::DocRegistry.new(cache: false)
@@ -125,6 +142,22 @@ RSpec.describe GemDocs::GemLoader do
         expect(loaded_gem.entry_points).to include("WellDocumented::Widget#call")
         expect(loaded_gem.objects.find { |object| object.path == "WellDocumented::Widget#call" }&.docstring)
           .to include("Performs work.")
+      end
+    end
+
+    it "builds a loaded gem for RDoc-backed gems through the RDoc provider" do
+      with_source_fixture_gem("rdoc_available", source: "module RdocAvailable; end\n") do
+        loaded_gem = instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :rdoc)
+        rdoc_provider = instance_double(GemDocs::DocProviders::Rdoc, load: loaded_gem, available?: true)
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: ->(_resolved_spec) { :source_only },
+          source_loader: ->(_resolved_spec) { raise "unused" },
+          loaded_gem_builder: ->(_resolved_spec, _objects, _doc_source) { raise "unused" },
+          rdoc_provider: rdoc_provider
+        )
+
+        expect(loader.load("rdoc_available")).to equal(loaded_gem)
       end
     end
 


### PR DESCRIPTION
## Summary
- add a dedicated `GemDocs::DocProviders::Rdoc` adapter for ri availability, index loading, lazy lookup, and cached hydration
- route `GemLoader` and `DocRegistry` through the provider while preserving source fallback behavior
- cover provider behavior, lazy hydration, and flag-like lookup targets with specs

Closes #37

## Test plan
- bundle exec rubocop -a
- bundle exec steep check
- bundle exec rspec