### PR TITLE
feat: add caching gem loader

### DIFF
--- a/lib/gem_docs/caching_gem_loader.rb
+++ b/lib/gem_docs/caching_gem_loader.rb
@@ -7,6 +7,9 @@ module GemDocs
       @cache = cache
       @invalidation_key_provider = invalidation_key_provider
       @loaded_gem_hydrator = loaded_gem_hydrator || ->(_spec, loaded_gem) { loaded_gem }
+      # @type var invalidation_keys: Hash[[String, String], String]
+      invalidation_keys = {}
+      @invalidation_keys = invalidation_keys
     end
 
     def load(name, version: nil, spec: nil)
@@ -29,7 +32,9 @@ module GemDocs
     end
 
     def invalidation_key_for(spec)
-      @invalidation_key_provider.call(spec)
+      @invalidation_keys.fetch(invalidation_cache_key(spec)) do
+        @invalidation_keys[invalidation_cache_key(spec)] = @invalidation_key_provider.call(spec)
+      end
     rescue StandardError
       nil
     end
@@ -65,6 +70,10 @@ module GemDocs
       @cache.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
     rescue StandardError
       nil
+    end
+
+    def invalidation_cache_key(spec)
+      [ spec.full_gem_path, spec.version.to_s ]
     end
   end
 end

--- a/lib/gem_docs/caching_gem_loader.rb
+++ b/lib/gem_docs/caching_gem_loader.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module GemDocs
+  class CachingGemLoader
+    def initialize(loader:, cache:, invalidation_key_provider:, loaded_gem_hydrator: nil)
+      @loader = loader
+      @cache = cache
+      @invalidation_key_provider = invalidation_key_provider
+      @loaded_gem_hydrator = loaded_gem_hydrator || ->(_spec, loaded_gem) { loaded_gem }
+    end
+
+    def load(name, version: nil, spec: nil)
+      spec ||= resolve_spec!(name, version: version)
+      invalidation_key = invalidation_key_for(spec)
+      cached_gem = fetch_cached_loaded_gem(spec, invalidation_key: invalidation_key)
+      return cached_gem if cached_gem
+
+      loaded_gem = @loader.load(name, version: version, spec: spec)
+      persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
+      loaded_gem
+    end
+
+    def detect_source(spec)
+      invalidation_key = invalidation_key_for(spec)
+      cached_gem = fetch_cached_loaded_gem(spec, invalidation_key: invalidation_key)
+      return cached_gem.doc_source if cached_gem
+
+      @loader.detect_source(spec)
+    end
+
+    def invalidation_key_for(spec)
+      @invalidation_key_provider.call(spec)
+    rescue StandardError
+      nil
+    end
+
+    def provider_available?(spec)
+      @loader.provider_available?(spec)
+    end
+
+    def resolve_spec!(name, version: nil)
+      @loader.resolve_spec!(name, version: version)
+    end
+
+    private
+
+    def fetch_cached_loaded_gem(spec, invalidation_key:)
+      return unless @cache && invalidation_key
+
+      cached_gem = @cache.fetch_loaded_gem(
+        gem_name: spec.name,
+        gem_version: spec.version.to_s,
+        invalidation_key: invalidation_key
+      )
+      return unless cached_gem
+
+      @loaded_gem_hydrator.call(spec, cached_gem)
+    rescue StandardError
+      nil
+    end
+
+    def persist_loaded_gem(loaded_gem, invalidation_key:)
+      return unless @cache && invalidation_key && loaded_gem
+
+      @cache.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/lib/gem_docs/caching_gem_loader.rb
+++ b/lib/gem_docs/caching_gem_loader.rb
@@ -13,14 +13,19 @@ module GemDocs
     end
 
     def load(name, version: nil, spec: nil)
+      loaded_gem, = load_with_invalidation_key(name, version: version, spec: spec)
+      loaded_gem
+    end
+
+    def load_with_invalidation_key(name, version: nil, spec: nil)
       spec ||= resolve_spec!(name, version: version)
       invalidation_key = invalidation_key_for(spec)
       cached_gem = fetch_cached_loaded_gem(spec, invalidation_key: invalidation_key)
-      return cached_gem if cached_gem
+      return [ cached_gem, invalidation_key ] if cached_gem
 
       loaded_gem = @loader.load(name, version: version, spec: spec)
       persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
-      loaded_gem
+      [ loaded_gem, invalidation_key ]
     end
 
     def detect_source(spec)

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -168,9 +168,8 @@ module GemDocs
 
       normalized_version = normalize_version(version)
       spec = @gem_loader.resolve_spec!(name, version: normalized_version)
-      loaded_gem = @gem_loader.load(name, version: normalized_version, spec: spec) ||
-        build_loaded_gem(spec, objects: [], doc_source: :none)
-      invalidation_key = invalidation_key_for_spec(spec)
+      loaded_gem, invalidation_key = load_with_invalidation_key(name, version: normalized_version, spec: spec)
+      loaded_gem ||= build_loaded_gem(spec, objects: [], doc_source: :none)
       @doc_sources[cache_key] = loaded_gem.doc_source
       ensure_source_artifacts_persisted(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
@@ -287,6 +286,14 @@ module GemDocs
       )
     rescue StandardError
       []
+    end
+
+    def load_with_invalidation_key(name, version:, spec:)
+      if @gem_loader.respond_to?(:load_with_invalidation_key)
+        @gem_loader.load_with_invalidation_key(name, version: version, spec: spec)
+      else
+        [ @gem_loader.load(name, version: version, spec: spec), invalidation_key_for_spec(spec) ]
+      end
     end
 
     def source_artifact_payload(loaded_gem, entry)

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -2,7 +2,6 @@
 
 require "open3"
 require "prism"
-require "digest"
 
 module GemDocs
   class DocRegistry
@@ -140,7 +139,7 @@ module GemDocs
         shell_runner: ->(command) { run_shell(*command) },
         loaded_gem_builder: loaded_gem_builder
       )
-      @gem_loader = gem_loader || GemLoader.new(
+      base_loader = GemLoader.new(
         spec_resolver: self.class.method(:gem_spec_for),
         doc_source_detector: method(:detect_doc_source),
         source_loader: method(:load_source_objects),
@@ -149,6 +148,16 @@ module GemDocs
         end,
         yard_provider: yard_provider,
         rdoc_provider: @rdoc_provider
+      )
+      invalidation_key_provider = InvalidationKeyProvider.new(
+        file_resolver: method(:ruby_files_for),
+        yardoc_resolver: method(:yardoc_path_for)
+      )
+      @gem_loader = gem_loader || CachingGemLoader.new(
+        loader: base_loader,
+        cache: @cache,
+        invalidation_key_provider: invalidation_key_provider,
+        loaded_gem_hydrator: method(:hydrate_loaded_gem)
       )
     end
 
@@ -159,20 +168,11 @@ module GemDocs
 
       normalized_version = normalize_version(version)
       spec = @gem_loader.resolve_spec!(name, version: normalized_version)
-
-      invalidation_key = safe_artifact_invalidation_key(spec)
-      cached_gem = fetch_cached_loaded_gem(spec, invalidation_key: invalidation_key)
-      if cached_gem
-        @doc_sources[cache_key] = cached_gem.doc_source
-        @loaded_gems[cache_key] = cached_gem
-        ensure_source_artifacts_persisted(cached_gem, invalidation_key: invalidation_key)
-        return cached_gem
-      end
-
       loaded_gem = @gem_loader.load(name, version: normalized_version, spec: spec) ||
         build_loaded_gem(spec, objects: [], doc_source: :none)
+      invalidation_key = invalidation_key_for_spec(spec)
       @doc_sources[cache_key] = loaded_gem.doc_source
-      persist_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
+      ensure_source_artifacts_persisted(loaded_gem, invalidation_key: invalidation_key)
       @loaded_gems[cache_key] = loaded_gem
     end
 
@@ -191,7 +191,7 @@ module GemDocs
 
     def artifact_invalidation_key_for(name, version: nil)
       spec = @gem_loader.resolve_spec!(name, version: version)
-      safe_artifact_invalidation_key(spec)
+      invalidation_key_for_spec(spec)
     end
 
     def source_artifacts_for(name, version: nil)
@@ -255,60 +255,6 @@ module GemDocs
       :none
     end
 
-    def artifact_invalidation_key(spec)
-      digest = Digest::SHA256.new
-      digest << "schema:#{GemDocs::ArtifactCache::SCHEMA_VERSION}\n"
-      digest << "gem:#{spec.name}\n"
-      digest << "version:#{spec.version}\n"
-      digest << "path:#{spec.full_gem_path}\n"
-
-      artifact_files_for(spec).sort.each do |file|
-        stat = File.stat(file)
-        digest << "file:#{file.delete_prefix("#{spec.full_gem_path}/")}\n"
-        digest << "size:#{stat.size}\n"
-        digest << "mtime:#{stat.mtime.to_r}\n"
-      end
-
-      digest.hexdigest
-    end
-
-    def artifact_files_for(spec)
-      files = ruby_files_for(spec)
-      yardoc = yardoc_path_for(spec)
-      files << yardoc if File.file?(yardoc)
-      files.uniq
-    end
-
-    def safe_artifact_invalidation_key(spec)
-      artifact_invalidation_key(spec)
-    rescue StandardError
-      nil
-    end
-
-    def fetch_cached_loaded_gem(spec, invalidation_key:)
-      return unless @cache && invalidation_key
-
-      cached_gem = @cache.fetch_loaded_gem(
-        gem_name: spec.name,
-        gem_version: spec.version.to_s,
-        invalidation_key: invalidation_key
-      )
-      return unless cached_gem
-
-      hydrate_cached_loaded_gem(spec, cached_gem)
-    rescue StandardError
-      nil
-    end
-
-    def persist_loaded_gem(loaded_gem, invalidation_key:)
-      return unless @cache && invalidation_key
-
-      @cache.write_loaded_gem(loaded_gem, invalidation_key: invalidation_key)
-      persist_source_artifacts(loaded_gem, invalidation_key: invalidation_key)
-    rescue StandardError
-      nil
-    end
-
     def persist_source_artifacts(loaded_gem, invalidation_key:)
       loaded_gem.objects.dup.each do |entry|
         resolved_entry = loaded_gem.find(entry.path) || entry
@@ -361,10 +307,16 @@ module GemDocs
       }
     end
 
-    def hydrate_cached_loaded_gem(spec, loaded_gem)
+    def hydrate_loaded_gem(spec, loaded_gem)
       return loaded_gem unless loaded_gem.doc_source == :rdoc
 
       @rdoc_provider.hydrate_loaded_gem(spec, loaded_gem)
+    end
+
+    def invalidation_key_for_spec(spec)
+      return unless @gem_loader.respond_to?(:invalidation_key_for)
+
+      @gem_loader.invalidation_key_for(spec)
     end
 
     def cache_key_for(name, version)

--- a/lib/gem_docs/invalidation_key_provider.rb
+++ b/lib/gem_docs/invalidation_key_provider.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module GemDocs
+  class InvalidationKeyProvider
+    def initialize(file_resolver:, yardoc_resolver:)
+      @file_resolver = file_resolver
+      @yardoc_resolver = yardoc_resolver
+    end
+
+    def call(spec)
+      digest = Digest::SHA256.new
+      digest << "schema:#{GemDocs::ArtifactCache::SCHEMA_VERSION}\n"
+      digest << "gem:#{spec.name}\n"
+      digest << "version:#{spec.version}\n"
+      digest << "path:#{spec.full_gem_path}\n"
+
+      artifact_files_for(spec).sort.each do |file|
+        stat = File.stat(file)
+        digest << "file:#{file.delete_prefix("#{spec.full_gem_path}/")}\n"
+        digest << "size:#{stat.size}\n"
+        digest << "mtime:#{stat.mtime.to_r}\n"
+      end
+
+      digest.hexdigest
+    end
+
+    private
+
+    def artifact_files_for(spec)
+      files = @file_resolver.call(spec)
+      yardoc = @yardoc_resolver.call(spec)
+      files << yardoc if File.file?(yardoc)
+      files.uniq
+    end
+  end
+end

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -55,6 +55,11 @@ module GemDocs
       ?loaded_gem_hydrator: ^(Gem::Specification, DocRegistry::LoadedGem) -> DocRegistry::LoadedGem
     ) -> void
     def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
+    def load_with_invalidation_key: (
+      String name,
+      ?version: String?,
+      ?spec: Gem::Specification?
+    ) -> [DocRegistry::LoadedGem?, String?]
     def detect_source: (Gem::Specification spec) -> doc_source
     def invalidation_key_for: (Gem::Specification spec) -> String?
     def provider_available?: (Gem::Specification spec) -> bool
@@ -298,7 +303,8 @@ module GemDocs
     ) -> LoadedGem
     def build_source_loaded_gem: (Gem::Specification spec, objects: Array[Entry], doc_source: doc_source) -> LoadedGem
     def persist_source_artifacts: (LoadedGem loaded_gem, invalidation_key: String) -> Array[Entry]
-    def ensure_source_artifacts_persisted: (LoadedGem loaded_gem, invalidation_key: String) -> Array[Hash[Symbol, untyped]]
+    def ensure_source_artifacts_persisted: (LoadedGem loaded_gem, invalidation_key: String?) -> Array[Hash[Symbol, untyped]]
+    def load_with_invalidation_key: (String name, version: String?, spec: Gem::Specification) -> [LoadedGem?, String?]
     def source_artifact_payload: (LoadedGem loaded_gem, Entry entry) -> Hash[String, untyped]
     def hydrate_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem
     def invalidation_key_for_spec: (Gem::Specification spec) -> String?

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -64,6 +64,7 @@ module GemDocs
 
     def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> DocRegistry::LoadedGem?
     def persist_loaded_gem: (DocRegistry::LoadedGem? loaded_gem, invalidation_key: String?) -> bool?
+    def invalidation_cache_key: (Gem::Specification spec) -> [String, String]
   end
 
   class InvalidationKeyProvider

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -47,6 +47,37 @@ module GemDocs
     def resolve_spec!: (String name, ?version: String?) -> Gem::Specification
   end
 
+  class CachingGemLoader
+    def initialize: (
+      loader: GemLoader,
+      cache: ArtifactCache?,
+      invalidation_key_provider: InvalidationKeyProvider,
+      ?loaded_gem_hydrator: ^(Gem::Specification, DocRegistry::LoadedGem) -> DocRegistry::LoadedGem
+    ) -> void
+    def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
+    def detect_source: (Gem::Specification spec) -> doc_source
+    def invalidation_key_for: (Gem::Specification spec) -> String?
+    def provider_available?: (Gem::Specification spec) -> bool
+    def resolve_spec!: (String name, ?version: String?) -> Gem::Specification
+
+    private
+
+    def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> DocRegistry::LoadedGem?
+    def persist_loaded_gem: (DocRegistry::LoadedGem? loaded_gem, invalidation_key: String?) -> bool?
+  end
+
+  class InvalidationKeyProvider
+    def initialize: (
+      file_resolver: ^(Gem::Specification) -> Array[String],
+      yardoc_resolver: ^(Gem::Specification) -> String
+    ) -> void
+    def call: (Gem::Specification spec) -> String
+
+    private
+
+    def artifact_files_for: (Gem::Specification spec) -> Array[String]
+  end
+
   module DocProviders
     class Rdoc
       def initialize: (
@@ -241,7 +272,7 @@ module GemDocs
     def initialize: (
       ?shell_runner: ^(Array[String]) -> command_response,
       ?cache: ArtifactCache?,
-      ?gem_loader: GemLoader?
+      ?gem_loader: (GemLoader | CachingGemLoader)?
     ) -> void
     def load_gem: (String name, ?version: String?) -> LoadedGem
     def doc_source_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> doc_source
@@ -265,15 +296,11 @@ module GemDocs
       ?lazy_paths: Array[String]
     ) -> LoadedGem
     def build_source_loaded_gem: (Gem::Specification spec, objects: Array[Entry], doc_source: doc_source) -> LoadedGem
-    def safe_artifact_invalidation_key: (Gem::Specification spec) -> String?
-    def fetch_cached_loaded_gem: (Gem::Specification spec, invalidation_key: String?) -> LoadedGem?
-    def hydrate_cached_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem
-    def persist_loaded_gem: (LoadedGem loaded_gem, invalidation_key: String?) -> bool?
     def persist_source_artifacts: (LoadedGem loaded_gem, invalidation_key: String) -> Array[Entry]
     def ensure_source_artifacts_persisted: (LoadedGem loaded_gem, invalidation_key: String) -> Array[Hash[Symbol, untyped]]
     def source_artifact_payload: (LoadedGem loaded_gem, Entry entry) -> Hash[String, untyped]
-    def artifact_invalidation_key: (Gem::Specification spec) -> String
-    def artifact_files_for: (Gem::Specification spec) -> Array[String]
+    def hydrate_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem
+    def invalidation_key_for_spec: (Gem::Specification spec) -> String?
     def resolve_spec: (String name, ?version: String?) -> Gem::Specification?
     def gem_description: (Gem::Specification spec) -> String?
     def gem_license: (Gem::Specification spec) -> String?

--- a/spec/caching_gem_loader_spec.rb
+++ b/spec/caching_gem_loader_spec.rb
@@ -181,10 +181,11 @@ RSpec.describe GemDocs::CachingGemLoader do
         invalidation_key_provider: invalidation_key_provider,
         loaded_gem_hydrator: ->(_spec, loaded_gem) { loaded_gem }
       )
+      spec = double("spec", full_gem_path: "/tmp/missing", version: "0.1.0")
 
       allow(invalidation_key_provider).to receive(:call).and_raise(Errno::ENOENT)
 
-      expect(loader.invalidation_key_for(double("spec"))).to be_nil
+      expect(loader.invalidation_key_for(spec)).to be_nil
     end
   end
 end

--- a/spec/caching_gem_loader_spec.rb
+++ b/spec/caching_gem_loader_spec.rb
@@ -146,6 +146,27 @@ RSpec.describe GemDocs::CachingGemLoader do
     end
   end
 
+  describe "#load_with_invalidation_key" do
+    it "returns the loaded gem together with the computed invalidation key" do
+      with_source_fixture_gem("cache_key_fixture", source: "module CacheKeyFixture; end\n") do |spec|
+        loaded_gem = build_loaded_gem(spec, source: :source_only)
+        base_loader = instance_double(GemDocs::GemLoader)
+        invalidation_key_provider = double("invalidation key provider", call: "digest-v1")
+
+        allow(base_loader).to receive(:resolve_spec!).with("cache_key_fixture", version: nil).and_return(spec)
+        allow(base_loader).to receive(:load).with("cache_key_fixture", version: nil, spec: spec).and_return(loaded_gem)
+
+        loader = described_class.new(
+          loader: base_loader,
+          cache: nil,
+          invalidation_key_provider: invalidation_key_provider
+        )
+
+        expect(loader.load_with_invalidation_key("cache_key_fixture")).to eq([ loaded_gem, "digest-v1" ])
+      end
+    end
+  end
+
   describe "#detect_source" do
     it "reads the doc source from cached snapshots" do
       with_source_fixture_gem("cached_source_fixture", source: "module CachedSourceFixture; end\n") do |spec|

--- a/spec/caching_gem_loader_spec.rb
+++ b/spec/caching_gem_loader_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "spec_helper"
+require "gem_docs"
+
+RSpec.describe GemDocs::CachingGemLoader do
+  def build_loaded_gem(spec, source:)
+    registry = GemDocs::DocRegistry.new(cache: false)
+    objects = registry.send(:load_source_objects, spec)
+    registry.send(:build_source_loaded_gem, spec, objects: objects, doc_source: source)
+  end
+
+  describe "#load" do
+    it "hydrates cached loaded gems from the artifact cache" do
+      with_source_fixture_gem("cached_fixture", source: "module CachedFixture; end\n") do |spec|
+        cached_gem = build_loaded_gem(spec, source: :source_only)
+        hydrated_gem = instance_double(GemDocs::DocRegistry::LoadedGem, doc_source: :source_only)
+        base_loader = instance_double(GemDocs::GemLoader)
+        invalidation_key_provider = double("invalidation key provider", call: "digest-v1")
+
+        Dir.mktmpdir do |tmpdir|
+          cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+          cache.write_loaded_gem(cached_gem, invalidation_key: "digest-v1")
+
+          allow(base_loader).to receive(:resolve_spec!).with("cached_fixture", version: nil).and_return(spec)
+          allow(base_loader).to receive(:load)
+
+          loader = described_class.new(
+            loader: base_loader,
+            cache: cache,
+            invalidation_key_provider: invalidation_key_provider,
+            loaded_gem_hydrator: lambda do |resolved_spec, loaded_gem|
+              expect(resolved_spec).to eq(spec)
+              expect(loaded_gem.name).to eq("cached_fixture")
+              hydrated_gem
+            end
+          )
+
+          expect(loader.load("cached_fixture")).to equal(hydrated_gem)
+          expect(base_loader).not_to have_received(:load)
+        end
+      end
+    end
+
+    it "persists loaded gems on cache misses" do
+      with_source_fixture_gem("cache_miss_fixture", source: <<~RUBY) do |spec|
+        module CacheMissFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        loaded_gem = build_loaded_gem(spec, source: :source_only)
+        base_loader = instance_double(GemDocs::GemLoader)
+        invalidation_key_provider = double("invalidation key provider", call: "digest-v1")
+
+        Dir.mktmpdir do |tmpdir|
+          cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+          allow(base_loader).to receive(:resolve_spec!).with("cache_miss_fixture", version: nil).and_return(spec)
+          allow(base_loader).to receive(:load).with("cache_miss_fixture", version: nil, spec: spec).and_return(loaded_gem)
+
+          loader = described_class.new(
+            loader: base_loader,
+            cache: cache,
+            invalidation_key_provider: invalidation_key_provider
+          )
+
+          expect(loader.load("cache_miss_fixture")).to eq(loaded_gem)
+          cached_gem = cache.fetch_loaded_gem(
+            gem_name: "cache_miss_fixture",
+            gem_version: "0.1.0",
+            invalidation_key: "digest-v1"
+          )
+          expect(cached_gem&.doc_source).to eq(:source_only)
+          expect(cached_gem&.objects&.map(&:path)).to include(
+            "CacheMissFixture",
+            "CacheMissFixture::Widget",
+            "CacheMissFixture::Widget#call"
+          )
+        end
+      end
+    end
+
+    it "ignores stale snapshots when the invalidation key changes" do
+      with_source_fixture_gem("stale_cache_fixture", source: "module StaleCacheFixture; end\n") do |spec|
+        stale_gem = build_loaded_gem(spec, source: :source_only)
+        fresh_gem = build_loaded_gem(spec, source: :none)
+        base_loader = instance_double(GemDocs::GemLoader)
+        invalidation_key_provider = double("invalidation key provider", call: "digest-v2")
+
+        Dir.mktmpdir do |tmpdir|
+          cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+          cache.write_loaded_gem(stale_gem, invalidation_key: "digest-v1")
+
+          allow(base_loader).to receive(:resolve_spec!).with("stale_cache_fixture", version: nil).and_return(spec)
+          allow(base_loader).to receive(:load).with("stale_cache_fixture", version: nil, spec: spec).and_return(fresh_gem)
+
+          loader = described_class.new(
+            loader: base_loader,
+            cache: cache,
+            invalidation_key_provider: invalidation_key_provider
+          )
+
+          expect(loader.load("stale_cache_fixture")).to eq(fresh_gem)
+          expect(base_loader).to have_received(:load).once
+        end
+      end
+    end
+
+    it "rebuilds when cached snapshots are corrupted" do
+      with_source_fixture_gem("corrupt_cache_fixture", source: "module CorruptCacheFixture; end\n") do |spec|
+        rebuilt_gem = build_loaded_gem(spec, source: :source_only)
+        base_loader = instance_double(GemDocs::GemLoader)
+        invalidation_key_provider = double("invalidation key provider", call: "digest-v1")
+
+        Dir.mktmpdir do |tmpdir|
+          cache_path = File.join(tmpdir, "artifacts.sqlite3")
+          cache = GemDocs::ArtifactCache.new(path: cache_path)
+          cache.write_loaded_gem(rebuilt_gem, invalidation_key: "digest-v1")
+
+          SQLite3::Database.new(cache_path).tap do |database|
+            database.execute(
+              "UPDATE documentation_artifacts SET payload = ? WHERE gem_name = ?",
+              "{",
+              "corrupt_cache_fixture"
+            )
+          ensure
+            database.close
+          end
+
+          allow(base_loader).to receive(:resolve_spec!).with("corrupt_cache_fixture", version: nil).and_return(spec)
+          allow(base_loader).to receive(:load).with("corrupt_cache_fixture", version: nil, spec: spec).and_return(rebuilt_gem)
+
+          loader = described_class.new(
+            loader: base_loader,
+            cache: cache,
+            invalidation_key_provider: invalidation_key_provider
+          )
+
+          expect(loader.load("corrupt_cache_fixture")).to eq(rebuilt_gem)
+          expect(base_loader).to have_received(:load).once
+        end
+      end
+    end
+  end
+
+  describe "#detect_source" do
+    it "reads the doc source from cached snapshots" do
+      with_source_fixture_gem("cached_source_fixture", source: "module CachedSourceFixture; end\n") do |spec|
+        cached_gem = build_loaded_gem(spec, source: :source_only)
+        base_loader = instance_double(GemDocs::GemLoader)
+        invalidation_key_provider = double("invalidation key provider", call: "digest-v1")
+
+        Dir.mktmpdir do |tmpdir|
+          cache = GemDocs::ArtifactCache.new(path: File.join(tmpdir, "artifacts.sqlite3"))
+          cache.write_loaded_gem(cached_gem, invalidation_key: "digest-v1")
+
+          allow(base_loader).to receive(:detect_source)
+
+          loader = described_class.new(
+            loader: base_loader,
+            cache: cache,
+            invalidation_key_provider: invalidation_key_provider
+          )
+
+          expect(loader.detect_source(spec)).to eq(:source_only)
+          expect(base_loader).not_to have_received(:detect_source)
+        end
+      end
+    end
+  end
+
+  describe "#invalidation_key_for" do
+    it "returns nil when invalidation key generation fails" do
+      invalidation_key_provider = double("invalidation key provider")
+      loader = described_class.new(
+        loader: instance_double(GemDocs::GemLoader),
+        cache: nil,
+        invalidation_key_provider: invalidation_key_provider,
+        loaded_gem_hydrator: ->(_spec, loaded_gem) { loaded_gem }
+      )
+
+      allow(invalidation_key_provider).to receive(:call).and_raise(Errno::ENOENT)
+
+      expect(loader.invalidation_key_for(double("spec"))).to be_nil
+    end
+  end
+end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -668,6 +668,43 @@ RSpec.describe GemDocs::DocRegistry do
         expect(registry.artifact_invalidation_key_for("invalidation_delegate_fixture")).to eq("digest-v1")
       end
     end
+
+    it "reuses the caching loader invalidation key during a load" do
+      with_source_fixture_gem("stable_invalidation_fixture", source: <<~RUBY) do |spec|
+        module StableInvalidationFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        cache = GemDocs::ArtifactCache.new(path: File.join(spec.full_gem_path, "cache.sqlite3"))
+        invalidation_key_provider = instance_double(GemDocs::InvalidationKeyProvider)
+        base_loader = instance_double(GemDocs::GemLoader)
+        caching_loader = GemDocs::CachingGemLoader.new(
+          loader: base_loader,
+          cache: cache,
+          invalidation_key_provider: invalidation_key_provider
+        )
+
+        registry = described_class.new(cache: cache, gem_loader: caching_loader)
+        loaded_gem = registry.send(
+          :build_source_loaded_gem,
+          spec,
+          objects: registry.send(:load_source_objects, spec),
+          doc_source: :source_only
+        )
+
+        allow(base_loader).to receive(:resolve_spec!).with("stable_invalidation_fixture", version: nil).and_return(spec)
+        allow(base_loader).to receive(:load).with("stable_invalidation_fixture", version: nil, spec: spec).and_return(loaded_gem)
+        allow(base_loader).to receive(:provider_available?).and_return(false)
+        allow(invalidation_key_provider).to receive(:call).with(spec).and_return("digest-v1")
+
+        registry.load_gem("stable_invalidation_fixture")
+
+        expect(invalidation_key_provider).to have_received(:call).once
+      end
+    end
   end
 
   describe "#find_object" do

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -44,6 +44,28 @@ RSpec.describe GemDocs::DocRegistry do
       end
     end
 
+    it "reuses the caching loader invalidation key returned during load" do
+      with_source_fixture_gem("source_only", source: "module SourceOnly; end\n") do |spec|
+        loaded_gem = instance_double(
+          GemDocs::DocRegistry::LoadedGem,
+          doc_source: :source_only,
+          name: "source_only",
+          version: "0.1.0",
+          objects: []
+        )
+        gem_loader = instance_double(GemDocs::CachingGemLoader)
+        allow(gem_loader).to receive(:resolve_spec!).with("source_only", version: nil).and_return(spec)
+        allow(gem_loader).to receive(:load_with_invalidation_key)
+          .with("source_only", version: nil, spec: spec)
+          .and_return([ loaded_gem, "digest-v1" ])
+
+        registry = described_class.new(cache: false, gem_loader: gem_loader)
+
+        expect(gem_loader).not_to receive(:invalidation_key_for)
+        expect(registry.load_gem("source_only")).to equal(loaded_gem)
+      end
+    end
+
     it "loads the shared local YARD fixture through the shared helper" do
       stub_fixture_gem("yard", name: "yard_fixture", yard: true) do
         registry = described_class.new

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe GemDocs::DocRegistry do
           cache_path = File.join(tmpdir, "artifacts.sqlite3")
           cache = GemDocs::ArtifactCache.new(path: cache_path)
           registry = described_class.new(cache: cache)
-          invalidation_key = registry.send(:artifact_invalidation_key, spec)
+          invalidation_key = registry.artifact_invalidation_key_for("corrupt_cache_fixture")
 
           cache.write_artifact(
             gem_name: "corrupt_cache_fixture",
@@ -652,6 +652,20 @@ RSpec.describe GemDocs::DocRegistry do
         registry = described_class.new
 
         expect(registry.doc_source_for("empty_source")).to eq(:none)
+      end
+    end
+  end
+
+  describe "#artifact_invalidation_key_for" do
+    it "delegates invalidation key generation to the gem loader" do
+      with_source_fixture_gem("invalidation_delegate_fixture", source: "module InvalidationDelegateFixture; end\n") do |spec|
+        gem_loader = instance_double(GemDocs::CachingGemLoader)
+        allow(gem_loader).to receive(:resolve_spec!).with("invalidation_delegate_fixture", version: nil).and_return(spec)
+        allow(gem_loader).to receive(:invalidation_key_for).with(spec).and_return("digest-v1")
+
+        registry = described_class.new(cache: false, gem_loader: gem_loader)
+
+        expect(registry.artifact_invalidation_key_for("invalidation_delegate_fixture")).to eq("digest-v1")
       end
     end
   end


### PR DESCRIPTION
## Summary
- introduce `CachingGemLoader` and `InvalidationKeyProvider` to own snapshot cache reads/writes and invalidation keys
- wire `DocRegistry` through the caching decorator while keeping source artifact persistence at the registry boundary
- add caching-focused specs for cache hits, misses, invalidation changes, corruption rebuilds, and registry delegation

Closes #38

## Test plan
- bundle exec rubocop -a
- bundle exec steep check
- bundle exec rspec