### PR TITLE
refactor: thin DocRegistry facade

### DIFF
--- a/lib/gem_docs/caching_gem_loader.rb
+++ b/lib/gem_docs/caching_gem_loader.rb
@@ -38,12 +38,13 @@ module GemDocs
       [ loaded_gem, invalidation_key ]
     end
 
-    def detect_source(spec)
+    def detect_source(name_or_spec, version: nil, spec: nil)
+      spec ||= name_or_spec.is_a?(String) ? resolve_spec!(name_or_spec, version: version) : name_or_spec
       invalidation_key = invalidation_key_for(spec)
       cached_gem = fetch_cached_loaded_gem(spec, invalidation_key: invalidation_key)
       return cached_gem.doc_source if cached_gem
 
-      @loader.detect_source(spec)
+      @loader.detect_source(name_or_spec, version: version, spec: spec)
     end
 
     def source_artifacts_for(name, version: nil, spec: nil)
@@ -68,7 +69,9 @@ module GemDocs
       nil
     end
 
-    def invalidation_key_for(spec)
+    def invalidation_key_for(name_or_spec, version: nil, spec: nil)
+      spec ||= name_or_spec.is_a?(String) ? resolve_spec!(name_or_spec, version: version) : name_or_spec
+
       @invalidation_keys.fetch(invalidation_cache_key(spec)) do
         @invalidation_keys[invalidation_cache_key(spec)] = @invalidation_key_provider.call(spec)
       end

--- a/lib/gem_docs/doc_registry.rb
+++ b/lib/gem_docs/doc_registry.rb
@@ -168,9 +168,7 @@ module GemDocs
       return loaded_gem if loaded_gem
 
       normalized_version = normalize_version(version)
-      spec = @gem_loader.resolve_spec!(name, version: normalized_version)
-      loaded_gem, invalidation_key = load_with_invalidation_key(name, version: normalized_version, spec: spec)
-      loaded_gem ||= build_loaded_gem(spec, objects: [], doc_source: :none)
+      loaded_gem = @gem_loader.load(name, version: normalized_version)
       @doc_sources[cache_key] = loaded_gem.doc_source
       @loaded_gems[cache_key] = loaded_gem
     end
@@ -181,24 +179,21 @@ module GemDocs
       return loaded_gem.doc_source if loaded_gem
 
       normalized_version = normalize_version(version)
-      spec ||= @gem_loader.resolve_spec!(name, version: normalized_version)
-
       @doc_sources.fetch(cache_key) do
-        @doc_sources[cache_key] = @gem_loader.detect_source(spec)
+        @doc_sources[cache_key] = @gem_loader.detect_source(name, version: normalized_version, spec: spec)
       end
     end
 
     def artifact_invalidation_key_for(name, version: nil)
-      spec = @gem_loader.resolve_spec!(name, version: version)
-      invalidation_key_for_spec(spec)
+      @gem_loader.invalidation_key_for(name, version: normalize_version(version))
     end
 
     def source_artifacts_for(name, version: nil)
-      @gem_loader.source_artifacts_for(name, version: version)
+      @gem_loader.source_artifacts_for(name, version: normalize_version(version))
     end
 
     def lookup_artifact_for(path, gem_name:, version: nil)
-      @gem_loader.lookup_artifact_for(path, gem_name: gem_name, version: version)
+      @gem_loader.lookup_artifact_for(path, gem_name: gem_name, version: normalize_version(version))
     end
 
     def find_object(path, gem_name:)
@@ -239,14 +234,6 @@ module GemDocs
       :none
     end
 
-    def load_with_invalidation_key(name, version:, spec:)
-      if @gem_loader.respond_to?(:load_with_invalidation_key)
-        @gem_loader.load_with_invalidation_key(name, version: version, spec: spec)
-      else
-        [ @gem_loader.load(name, version: version, spec: spec), invalidation_key_for_spec(spec) ]
-      end
-    end
-
     def source_artifact_payload(loaded_gem, entry)
       {
         "gem_name" => loaded_gem.name,
@@ -271,12 +258,6 @@ module GemDocs
       @rdoc_provider.hydrate_loaded_gem(spec, loaded_gem)
     end
 
-    def invalidation_key_for_spec(spec)
-      return unless @gem_loader.respond_to?(:invalidation_key_for)
-
-      @gem_loader.invalidation_key_for(spec)
-    end
-
     def cache_key_for(name, version)
       normalized_version = normalize_version(version)
       return name if normalized_version.nil?
@@ -288,12 +269,6 @@ module GemDocs
       return nil if version.nil? || version.empty?
 
       version
-    end
-
-    def resolve_spec(name, version: nil)
-      @gem_loader.resolve_spec!(name, version: version)
-    rescue GemDocs::GemNotFound
-      nil
     end
 
     def build_loaded_gem(spec, objects:, doc_source:, dynamic_lookup: nil, lazy_paths: [])

--- a/lib/gem_docs/gem_loader.rb
+++ b/lib/gem_docs/gem_loader.rb
@@ -21,12 +21,29 @@ module GemDocs
     def load(name, version: nil, spec: nil)
       spec ||= resolve_spec!(name, version: version)
       doc_source = detect_source(spec)
-      return @yard_provider.load(spec) if doc_source == :yard && @yard_provider
-      return @rdoc_provider.load(spec) if doc_source == :rdoc && @rdoc_provider
-      return load_fallback(spec) if [ :yard, :rdoc ].include?(doc_source)
-      return unless doc_source == :source_only || doc_source == :none
+      case doc_source
+      when :yard
+        loaded_gem = @yard_provider&.load(spec)
+        return loaded_gem if loaded_gem
 
-      load_fallback(spec, doc_source: doc_source)
+        return load_fallback(spec)
+      when :rdoc
+        loaded_gem = @rdoc_provider&.load(spec)
+        return loaded_gem if loaded_gem
+
+        return load_fallback(spec)
+      when :source_only, :none
+        return load_fallback(spec, doc_source: doc_source)
+      end
+
+      raise GemDocs::RegistryError.new(
+        "Unsupported documentation source: #{doc_source.inspect}",
+        details: {
+          gem_name: spec.name,
+          gem_version: spec.version.to_s,
+          doc_source: doc_source
+        }
+      )
     end
 
     def detect_source(name_or_spec, version: nil, spec: nil)
@@ -38,14 +55,17 @@ module GemDocs
     end
 
     def invalidation_key_for(_name, version: nil, spec: nil)
+      _unused = [ version, spec ]
       nil
     end
 
     def source_artifacts_for(_name, version: nil, spec: nil)
+      _unused = [ version, spec ]
       []
     end
 
     def lookup_artifact_for(_path, gem_name:, version: nil, spec: nil)
+      _unused = [ gem_name, version, spec ]
       nil
     end
 

--- a/lib/gem_docs/gem_loader.rb
+++ b/lib/gem_docs/gem_loader.rb
@@ -29,11 +29,24 @@ module GemDocs
       load_fallback(spec, doc_source: doc_source)
     end
 
-    def detect_source(spec)
+    def detect_source(name_or_spec, version: nil, spec: nil)
+      spec ||= name_or_spec.is_a?(String) ? resolve_spec!(name_or_spec, version: version) : name_or_spec
       return :yard if @yard_provider&.available?(spec)
       return :rdoc if @rdoc_provider&.available?(spec)
 
       @doc_source_detector.call(spec)
+    end
+
+    def invalidation_key_for(_name, version: nil, spec: nil)
+      nil
+    end
+
+    def source_artifacts_for(_name, version: nil, spec: nil)
+      []
+    end
+
+    def lookup_artifact_for(_path, gem_name:, version: nil, spec: nil)
+      nil
     end
 
     def provider_available?(spec)

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -41,7 +41,15 @@ module GemDocs
       ?rdoc_provider: DocProviders::Rdoc?
     ) -> void
     def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
-    def detect_source: (Gem::Specification spec) -> doc_source
+    def detect_source: ((String | Gem::Specification) name_or_spec, ?version: String?, ?spec: Gem::Specification?) -> doc_source
+    def invalidation_key_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> nil
+    def source_artifacts_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> Array[Hash[Symbol, untyped]]
+    def lookup_artifact_for: (
+      String path,
+      gem_name: String,
+      ?version: String?,
+      ?spec: Gem::Specification?
+    ) -> nil
     def provider_available?: (Gem::Specification spec) -> bool
     def load_fallback: (Gem::Specification spec, ?doc_source: doc_source?) -> DocRegistry::LoadedGem
     def resolve_spec!: (String name, ?version: String?) -> Gem::Specification
@@ -61,7 +69,7 @@ module GemDocs
       ?version: String?,
       ?spec: Gem::Specification?
     ) -> [DocRegistry::LoadedGem?, String?]
-    def detect_source: (Gem::Specification spec) -> doc_source
+    def detect_source: ((String | Gem::Specification) name_or_spec, ?version: String?, ?spec: Gem::Specification?) -> doc_source
     def source_artifacts_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> Array[Hash[Symbol, untyped]]
     def lookup_artifact_for: (
       String path,
@@ -69,7 +77,7 @@ module GemDocs
       ?version: String?,
       ?spec: Gem::Specification?
     ) -> { kind: Symbol, payload: untyped }?
-    def invalidation_key_for: (Gem::Specification spec) -> String?
+    def invalidation_key_for: ((String | Gem::Specification) name_or_spec, ?version: String?, ?spec: Gem::Specification?) -> String?
     def provider_available?: (Gem::Specification spec) -> bool
     def resolve_spec!: (String name, ?version: String?) -> Gem::Specification
 
@@ -315,11 +323,8 @@ module GemDocs
       ?lazy_paths: Array[String]
     ) -> LoadedGem
     def build_source_loaded_gem: (Gem::Specification spec, objects: Array[Entry], doc_source: doc_source) -> LoadedGem
-    def load_with_invalidation_key: (String name, version: String?, spec: Gem::Specification) -> [LoadedGem?, String?]
     def source_artifact_payload: (LoadedGem loaded_gem, Entry entry) -> Hash[String, untyped]
     def hydrate_loaded_gem: (Gem::Specification spec, LoadedGem loaded_gem) -> LoadedGem
-    def invalidation_key_for_spec: (Gem::Specification spec) -> String?
-    def resolve_spec: (String name, ?version: String?) -> Gem::Specification?
     def gem_description: (Gem::Specification spec) -> String?
     def gem_license: (Gem::Specification spec) -> String?
     def infer_entry_points: (String gem_name, Array[Entry] objects, doc_source: doc_source) -> Array[String]

--- a/sig/gem_docs.rbs
+++ b/sig/gem_docs.rbs
@@ -40,7 +40,7 @@ module GemDocs
       ?yard_provider: DocProviders::Yard?,
       ?rdoc_provider: DocProviders::Rdoc?
     ) -> void
-    def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
+    def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem
     def detect_source: ((String | Gem::Specification) name_or_spec, ?version: String?, ?spec: Gem::Specification?) -> doc_source
     def invalidation_key_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> nil
     def source_artifacts_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> Array[Hash[Symbol, untyped]]
@@ -63,12 +63,12 @@ module GemDocs
       ?loaded_gem_hydrator: ^(Gem::Specification, DocRegistry::LoadedGem) -> DocRegistry::LoadedGem,
       ?source_artifact_builder: ^(DocRegistry::LoadedGem, DocRegistry::Entry) -> Hash[String, untyped]
     ) -> void
-    def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem?
+    def load: (String name, ?version: String?, ?spec: Gem::Specification?) -> DocRegistry::LoadedGem
     def load_with_invalidation_key: (
       String name,
       ?version: String?,
       ?spec: Gem::Specification?
-    ) -> [DocRegistry::LoadedGem?, String?]
+    ) -> [DocRegistry::LoadedGem, String?]
     def detect_source: ((String | Gem::Specification) name_or_spec, ?version: String?, ?spec: Gem::Specification?) -> doc_source
     def source_artifacts_for: (String name, ?version: String?, ?spec: Gem::Specification?) -> Array[Hash[Symbol, untyped]]
     def lookup_artifact_for: (

--- a/spec/caching_gem_loader_spec.rb
+++ b/spec/caching_gem_loader_spec.rb
@@ -402,5 +402,35 @@ RSpec.describe GemDocs::CachingGemLoader do
 
       expect(loader.invalidation_key_for(spec)).to be_nil
     end
+
+    it "reuses the cached invalidation key after a load" do
+      with_source_fixture_gem("stable_invalidation_fixture", source: <<~RUBY) do |spec|
+        module StableInvalidationFixture
+          class Widget
+            def call(input)
+            end
+          end
+        end
+      RUBY
+        loaded_gem = build_loaded_gem(spec, source: :source_only)
+        invalidation_key_provider = instance_double(GemDocs::InvalidationKeyProvider)
+        base_loader = instance_double(GemDocs::GemLoader)
+
+        allow(base_loader).to receive(:resolve_spec!).with("stable_invalidation_fixture", version: nil).and_return(spec)
+        allow(base_loader).to receive(:load).with("stable_invalidation_fixture", version: nil, spec: spec).and_return(loaded_gem)
+        allow(invalidation_key_provider).to receive(:call).with(spec).and_return("digest-v1")
+
+        loader = described_class.new(
+          loader: base_loader,
+          cache: nil,
+          invalidation_key_provider: invalidation_key_provider
+        )
+
+        loader.load("stable_invalidation_fixture")
+
+        expect(loader.invalidation_key_for("stable_invalidation_fixture")).to eq("digest-v1")
+        expect(invalidation_key_provider).to have_received(:call).once
+      end
+    end
   end
 end

--- a/spec/doc_registry_spec.rb
+++ b/spec/doc_registry_spec.rb
@@ -7,63 +7,33 @@ require "gem_docs"
 RSpec.describe GemDocs::DocRegistry do
   describe "#load_gem" do
     it "uses the gem loader for the source-only fallback path" do
-      with_source_fixture_gem("source_only", source: "module SourceOnly; end\n") do |spec|
-        loaded_gem = instance_double(
-          GemDocs::DocRegistry::LoadedGem,
-          doc_source: :source_only,
-          name: "source_only",
-          version: "0.1.0"
-        )
-        gem_loader = instance_double(GemDocs::GemLoader)
-        allow(gem_loader).to receive(:resolve_spec!).with("source_only", version: nil).and_return(spec)
-        allow(gem_loader).to receive(:provider_available?).with(spec).and_return(false)
-        allow(gem_loader).to receive(:load).with("source_only", version: nil, spec: spec).and_return(loaded_gem)
+      loaded_gem = instance_double(
+        GemDocs::DocRegistry::LoadedGem,
+        doc_source: :source_only,
+        name: "source_only",
+        version: "0.1.0"
+      )
+      gem_loader = instance_double(GemDocs::GemLoader)
+      allow(gem_loader).to receive(:load).with("source_only", version: nil).and_return(loaded_gem)
 
-        registry = described_class.new(cache: false, gem_loader: gem_loader)
+      registry = described_class.new(cache: false, gem_loader: gem_loader)
 
-        expect(registry.load_gem("source_only")).to equal(loaded_gem)
-      end
+      expect(registry.load_gem("source_only")).to equal(loaded_gem)
     end
 
     it "uses the gem loader for the YARD path" do
-      with_yard_fixture_gem("well_documented", source: "module WellDocumented; end\n") do |spec|
-        loaded_gem = instance_double(
-          GemDocs::DocRegistry::LoadedGem,
-          doc_source: :yard,
-          name: "well_documented",
-          version: "0.1.0"
-        )
-        gem_loader = instance_double(GemDocs::GemLoader)
-        allow(gem_loader).to receive(:resolve_spec!).with("well_documented", version: nil).and_return(spec)
-        allow(gem_loader).to receive(:provider_available?).with(spec).and_return(true)
-        allow(gem_loader).to receive(:load).with("well_documented", version: nil, spec: spec).and_return(loaded_gem)
+      loaded_gem = instance_double(
+        GemDocs::DocRegistry::LoadedGem,
+        doc_source: :yard,
+        name: "well_documented",
+        version: "0.1.0"
+      )
+      gem_loader = instance_double(GemDocs::GemLoader)
+      allow(gem_loader).to receive(:load).with("well_documented", version: nil).and_return(loaded_gem)
 
-        registry = described_class.new(cache: false, gem_loader: gem_loader)
+      registry = described_class.new(cache: false, gem_loader: gem_loader)
 
-        expect(registry.load_gem("well_documented")).to equal(loaded_gem)
-      end
-    end
-
-    it "reuses the caching loader invalidation key returned during load" do
-      with_source_fixture_gem("source_only", source: "module SourceOnly; end\n") do |spec|
-        loaded_gem = instance_double(
-          GemDocs::DocRegistry::LoadedGem,
-          doc_source: :source_only,
-          name: "source_only",
-          version: "0.1.0",
-          objects: []
-        )
-        gem_loader = instance_double(GemDocs::CachingGemLoader)
-        allow(gem_loader).to receive(:resolve_spec!).with("source_only", version: nil).and_return(spec)
-        allow(gem_loader).to receive(:load_with_invalidation_key)
-          .with("source_only", version: nil, spec: spec)
-          .and_return([ loaded_gem, "digest-v1" ])
-
-        registry = described_class.new(cache: false, gem_loader: gem_loader)
-
-        expect(gem_loader).not_to receive(:invalidation_key_for)
-        expect(registry.load_gem("source_only")).to equal(loaded_gem)
-      end
+      expect(registry.load_gem("well_documented")).to equal(loaded_gem)
     end
 
     it "loads the shared local YARD fixture through the shared helper" do
@@ -626,15 +596,12 @@ RSpec.describe GemDocs::DocRegistry do
 
   describe "#doc_source_for" do
     it "uses the gem loader to detect no-doc gems" do
-      with_empty_fixture_gem("empty_fixture") do |spec|
-        gem_loader = instance_double(GemDocs::GemLoader)
-        allow(gem_loader).to receive(:resolve_spec!).with("empty_fixture", version: nil).and_return(spec)
-        allow(gem_loader).to receive(:detect_source).with(spec).and_return(:none)
+      gem_loader = instance_double(GemDocs::GemLoader)
+      allow(gem_loader).to receive(:detect_source).with("empty_fixture", version: nil, spec: nil).and_return(:none)
 
-        registry = described_class.new(cache: false, gem_loader: gem_loader)
+      registry = described_class.new(cache: false, gem_loader: gem_loader)
 
-        expect(registry.doc_source_for("empty_fixture")).to eq(:none)
-      end
+      expect(registry.doc_source_for("empty_fixture")).to eq(:none)
     end
 
     it "reuses cached versioned loads for doc source lookups" do
@@ -726,52 +693,14 @@ RSpec.describe GemDocs::DocRegistry do
 
   describe "#artifact_invalidation_key_for" do
     it "delegates invalidation key generation to the gem loader" do
-      with_source_fixture_gem("invalidation_delegate_fixture", source: "module InvalidationDelegateFixture; end\n") do |spec|
-        gem_loader = instance_double(GemDocs::CachingGemLoader)
-        allow(gem_loader).to receive(:resolve_spec!).with("invalidation_delegate_fixture", version: nil).and_return(spec)
-        allow(gem_loader).to receive(:invalidation_key_for).with(spec).and_return("digest-v1")
+      gem_loader = instance_double(GemDocs::CachingGemLoader)
+      allow(gem_loader).to receive(:invalidation_key_for)
+        .with("invalidation_delegate_fixture", version: nil)
+        .and_return("digest-v1")
 
-        registry = described_class.new(cache: false, gem_loader: gem_loader)
+      registry = described_class.new(cache: false, gem_loader: gem_loader)
 
-        expect(registry.artifact_invalidation_key_for("invalidation_delegate_fixture")).to eq("digest-v1")
-      end
-    end
-
-    it "reuses the caching loader invalidation key during a load" do
-      with_source_fixture_gem("stable_invalidation_fixture", source: <<~RUBY) do |spec|
-        module StableInvalidationFixture
-          class Widget
-            def call(input)
-            end
-          end
-        end
-      RUBY
-        cache = GemDocs::ArtifactCache.new(path: File.join(spec.full_gem_path, "cache.sqlite3"))
-        invalidation_key_provider = instance_double(GemDocs::InvalidationKeyProvider)
-        base_loader = instance_double(GemDocs::GemLoader)
-        caching_loader = GemDocs::CachingGemLoader.new(
-          loader: base_loader,
-          cache: cache,
-          invalidation_key_provider: invalidation_key_provider
-        )
-
-        registry = described_class.new(cache: cache, gem_loader: caching_loader)
-        loaded_gem = registry.send(
-          :build_source_loaded_gem,
-          spec,
-          objects: registry.send(:load_source_objects, spec),
-          doc_source: :source_only
-        )
-
-        allow(base_loader).to receive(:resolve_spec!).with("stable_invalidation_fixture", version: nil).and_return(spec)
-        allow(base_loader).to receive(:load).with("stable_invalidation_fixture", version: nil, spec: spec).and_return(loaded_gem)
-        allow(base_loader).to receive(:provider_available?).and_return(false)
-        allow(invalidation_key_provider).to receive(:call).with(spec).and_return("digest-v1")
-
-        registry.load_gem("stable_invalidation_fixture")
-
-        expect(invalidation_key_provider).to have_received(:call).once
-      end
+      expect(registry.artifact_invalidation_key_for("invalidation_delegate_fixture")).to eq("digest-v1")
     end
   end
 

--- a/spec/gem_loader_spec.rb
+++ b/spec/gem_loader_spec.rb
@@ -232,6 +232,20 @@ RSpec.describe GemDocs::GemLoader do
         expect(loaded_gem.entry_points).to eq([])
       end
     end
+
+    it "raises a registry error when the detector returns an unsupported source" do
+      with_source_fixture_gem("source_only", source: "module SourceOnly; end\n") do
+        loader = described_class.new(
+          spec_resolver: GemDocs::DocRegistry.method(:gem_spec_for),
+          doc_source_detector: ->(_resolved_spec) { :unexpected },
+          source_loader: ->(_resolved_spec) { raise "unused" },
+          loaded_gem_builder: ->(_resolved_spec, _objects, _doc_source) { raise "unused" }
+        )
+
+        expect { loader.load("source_only") }
+          .to raise_error(GemDocs::RegistryError, "Unsupported documentation source: :unexpected")
+      end
+    end
   end
 
   describe "#load_fallback" do


### PR DESCRIPTION
## Summary
- make `DocRegistry` delegate load, source detection, invalidation, and artifact lookups directly to the loader boundary
- give `GemLoader`/`CachingGemLoader` a consistent facade-friendly API for source detection and invalidation lookups
- trim DocRegistry orchestration specs and move invalidation-key reuse coverage to `CachingGemLoader`

Closes #40

## Test plan
- bundle exec rubocop -a
- bundle exec steep check
- bundle exec rspec